### PR TITLE
Use the node type for messages instead of string

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "karma-webpack": "^1.7.0",
     "less": "^2.5.1",
     "less-loader": "^2.2.0",
-    "markdown-jsx-loader": "^1.0.0",
+    "markdown-jsx-loader": "^2.0.0",
     "marked": "^0.3.5",
     "mocha": "^2.2.5",
     "moment": "^2.10.6",

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -276,14 +276,14 @@ let Calendar = React.createClass({
      * String messages used throughout the component, override to provide localizations
      */
     messages: PropTypes.shape({
-      allDay: PropTypes.string,
-      previous: PropTypes.string,
-      next: PropTypes.string,
-      today: PropTypes.string,
-      month: PropTypes.string,
-      week: PropTypes.string,
-      day: PropTypes.string,
-      agenda: PropTypes.string,
+      allDay: PropTypes.node,
+      previous: PropTypes.node,
+      next: PropTypes.node,
+      today: PropTypes.node,
+      month: PropTypes.node,
+      week: PropTypes.node,
+      day: PropTypes.node,
+      agenda: PropTypes.node,
       showMore: PropTypes.func
     })
   },


### PR DESCRIPTION
This already works, no code change is needed; this just fixes the warning you get by doing so.

This turns out to be very useful for formatting button text or replacing it with an icon.