### PR TITLE
Don't treat with-time events that extend into the morning as all-day events

### DIFF
--- a/examples/events.js
+++ b/examples/events.js
@@ -53,5 +53,15 @@ export default [
     "title": "Birthday Party",
     "start":new Date(2015, 3, 13, 7, 0, 0),
     "end": new Date(2015, 3, 13, 10, 30, 0)
+  },
+  {
+    "title": "Late Night Event",
+    "start":new Date(2015, 3, 17, 19, 30, 0),
+    "end": new Date(2015, 3, 18, 2, 0, 0)
+  },
+  {
+    "title": "Multi-day Event",
+    "start":new Date(2015, 3, 20, 19, 30, 0),
+    "end": new Date(2015, 3, 22, 2, 0, 0)
   }
 ]

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -12,6 +12,7 @@ import { notify } from './utils/helpers';
 import { navigate, views } from './utils/constants';
 import dates from './utils/dates';
 import defaultFormats from './formats';
+import message from './utils/messages';
 import viewLabel from './utils/viewLabel';
 import moveDate from './utils/move';
 import VIEWS from './Views';
@@ -309,12 +310,14 @@ let Calendar = React.createClass({
       , culture
       , components = {}
       , formats = {}
+      , messages = {}
       , style
       , className
       , date: current
       , ...props } = this.props;
 
     formats = defaultFormats(formats)
+    messages = message(messages)
 
     let View = VIEWS[view];
     let names = viewNames(this.props.views)
@@ -341,13 +344,14 @@ let Calendar = React.createClass({
             label={viewLabel(current, view, formats, culture)}
             onViewChange={this._view}
             onNavigate={this._navigate}
-            messages={this.props.messages}
+            messages={messages}
           />
         }
         <View
           ref='view'
           {...props}
           {...formats}
+          messages={messages}
           culture={culture}
           formats={undefined}
           events={events}

--- a/src/DaySlot.jsx
+++ b/src/DaySlot.jsx
@@ -170,7 +170,7 @@ let DaySlot = React.createClass({
         <div
           key={'evt_' + idx}
           style={{...xStyle, ...style}}
-          title={(typeof label ? label + ': ' : '') + title }
+          title={(typeof label === 'string' ? label + ': ' : '') + title }
           onClick={this._select.bind(null, event)}
           className={cn('rbc-event', className, {
             'rbc-selected': _isSelected,

--- a/src/DaySlot.jsx
+++ b/src/DaySlot.jsx
@@ -119,9 +119,9 @@ let DaySlot = React.createClass({
 
   renderEvents(numSlots, totalMin) {
     let {
-        events, step, min, culture, eventPropGetter
-      , selected, eventTimeRangeFormat, eventComponent
-      , startAccessor, endAccessor, titleAccessor } = this.props;
+        events, step, min, max, culture, eventPropGetter, selected, messages
+      , eventTimeRangeFormat, eventTimeRangeStartFormat, eventTimeRangeEndFormat
+      , eventComponent, startAccessor, endAccessor, titleAccessor } = this.props;
 
     let EventComponent = eventComponent
       , lastLeftOffset = 0;
@@ -129,8 +129,22 @@ let DaySlot = React.createClass({
     events.sort((a, b) => +get(a, startAccessor) - +get(b, startAccessor))
 
     return events.map((event, idx) => {
+      let _eventTimeRangeFormat = eventTimeRangeFormat;
+      let _continuesPrior = false;
+      let _continuesAfter = false;
       let start = get(event, startAccessor)
       let end = get(event, endAccessor)
+      if ( start < min ) {
+        start = min;
+        _continuesPrior = true;
+        _eventTimeRangeFormat = eventTimeRangeEndFormat;
+      }
+      if ( end > max ) {
+        end = max;
+        _continuesAfter = true;
+        _eventTimeRangeFormat = eventTimeRangeStartFormat;
+      }
+
       let startSlot = positionFromDate(start, min, step);
       let endSlot = positionFromDate(end, min, step);
 
@@ -140,7 +154,13 @@ let DaySlot = React.createClass({
       let style = this._slotStyle(startSlot, endSlot, lastLeftOffset)
 
       let title = get(event, titleAccessor)
-      let label = localizer.format({ start, end }, eventTimeRangeFormat, culture);
+      let label;
+      if ( _continuesPrior && _continuesAfter ) {
+        label = messages.allDay;
+      } else {
+        label = localizer.format({ start, end }, _eventTimeRangeFormat, culture);
+      }
+
       let _isSelected = isSelected(event, selected);
 
       if (eventPropGetter)
@@ -150,11 +170,13 @@ let DaySlot = React.createClass({
         <div
           key={'evt_' + idx}
           style={{...xStyle, ...style}}
-          title={label + ': ' + title }
+          title={(typeof label ? label + ': ' : '') + title }
           onClick={this._select.bind(null, event)}
           className={cn('rbc-event', className, {
             'rbc-selected': _isSelected,
-            'rbc-event-overlaps': lastLeftOffset !== 0
+            'rbc-event-overlaps': lastLeftOffset !== 0,
+            'rbc-event-continues-day-prior': _continuesPrior,
+            'rbc-event-continues-day-after': _continuesAfter
           })}
         >
           <div className='rbc-event-label'>{label}</div>

--- a/src/TimeGrid.jsx
+++ b/src/TimeGrid.jsx
@@ -78,8 +78,7 @@ let TimeGrid = React.createClass({
 
         if (
              get(event, allDayAccessor)
-          || !dates.eq(eStart, eEnd, 'day')
-          || (dates.isJustDate(eStart) && dates.isJustDate(eEnd)))
+          || (dates.isJustDate(eStart) && (dates.isJustDate(eEnd) || dates.isJustDate(dates.add(eEnd, 1, 'millisecond')))))
         {
           allDayEvents.push(event)
         }

--- a/src/Toolbar.jsx
+++ b/src/Toolbar.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import cn from 'classnames';
-import message from './utils/messages';
 import { navigate } from './utils/constants';
 
 let Toolbar = React.createClass({
@@ -9,8 +8,6 @@ let Toolbar = React.createClass({
     let {
         messages, label
       , views: viewNames, view } = this.props;
-
-    messages = message(messages)
 
     return (
       <div className='rbc-toolbar'>

--- a/src/formats.js
+++ b/src/formats.js
@@ -13,6 +13,12 @@ let timeRangeFormat = ({ start, end }, culture, local)=>
   local.format(start, 'h:mmtt', culture) +
     ' — ' + local.format(end, inSame12Hr(start, end) ? 'h:mm' : 'h:mmtt', culture)
 
+let timeRangeStartFormat = ({ start, end }, culture, local)=>
+  local.format(start, 'h:mmtt', culture) +' — '
+
+let timeRangeEndFormat = ({ start, end }, culture, local)=>
+  ' — ' + local.format(end, 'h:mmtt', culture)
+
 let weekRangeFormat = ({ start, end }, culture, local)=>
   local.format(start, 'MMM dd', culture) +
     ' - ' + local.format(end, dates.eq(start, end, 'month') ? 'dd' : 'MMM dd', culture)
@@ -25,6 +31,8 @@ let formats = {
 
   selectRangeFormat: timeRangeFormat,
   eventTimeRangeFormat: timeRangeFormat,
+  eventTimeRangeStartFormat: timeRangeStartFormat,
+  eventTimeRangeEndFormat: timeRangeEndFormat,
 
   timeGutterFormat: 'h:mm tt',
 

--- a/src/less/event.less
+++ b/src/less/event.less
@@ -30,3 +30,13 @@
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
 }
+
+.rbc-event-continues-day-after {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.rbc-event-continues-day-prior {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}

--- a/src/localizers/globalize.js
+++ b/src/localizers/globalize.js
@@ -10,6 +10,12 @@ let timeRangeFormat = ({ start, end }, culture, local)=>
   local.format(start, { time: 'short' }, culture) +
     ' — ' + local.format(end, { time: 'short' }, culture)
 
+let timeRangeStartFormat = ({ start, end }, culture, local)=>
+  local.format(start, 't', culture) + ' — '
+
+let timeRangeEndFormat = ({ start, end }, culture, local)=>
+  ' — ' + local.format(end, 't', culture)
+
 let weekRangeFormat = ({ start, end }, culture, local)=>
   local.format(start, 'MMM dd', culture) +
     ' — ' + local.format(end, dates.eq(start, end, 'month') ? 'dd' : 'MMM dd', culture)
@@ -21,6 +27,8 @@ export let formats = {
 
   selectRangeFormat: timeRangeFormat,
   eventTimeRangeFormat: timeRangeFormat,
+  eventTimeRangeStartFormat: timeRangeStartFormat,
+  eventTimeRangeEndFormat: timeRangeEndFormat,
 
   timeGutterFormat: { time: 'short' },
 

--- a/src/localizers/globalize.js
+++ b/src/localizers/globalize.js
@@ -11,10 +11,10 @@ let timeRangeFormat = ({ start, end }, culture, local)=>
     ' — ' + local.format(end, { time: 'short' }, culture)
 
 let timeRangeStartFormat = ({ start, end }, culture, local)=>
-  local.format(start, 't', culture) + ' — '
+  local.format(start, { time: 'short' }, culture) + ' — '
 
 let timeRangeEndFormat = ({ start, end }, culture, local)=>
-  ' — ' + local.format(end, 't', culture)
+  ' — ' + local.format(end, { time: 'short' }, culture)
 
 let weekRangeFormat = ({ start, end }, culture, local)=>
   local.format(start, 'MMM dd', culture) +

--- a/src/localizers/moment.js
+++ b/src/localizers/moment.js
@@ -15,6 +15,12 @@ let timeRangeFormat = ({ start, end }, culture, local)=>
   local.format(start, 'h:mma', culture) +
     ' — ' + local.format(end, inSame12Hr(start, end) ? 'h:mm' : 'h:mma', culture)
 
+let timeRangeStartFormat = ({ start, end }, culture, local)=>
+  local.format(start, 'h:mmtt', culture) +' — '
+
+let timeRangeEndFormat = ({ start, end }, culture, local)=>
+  ' — ' + local.format(end, 'h:mmtt', culture)
+
 let weekRangeFormat = ({ start, end }, culture, local)=>
   local.format(start, 'MMM DD', culture) +
     ' - ' + local.format(end, dates.eq(start, end, 'month') ? 'DD' : 'MMM DD', culture)
@@ -26,6 +32,8 @@ export let formats = {
 
   selectRangeFormat: timeRangeFormat,
   eventTimeRangeFormat: timeRangeFormat,
+  eventTimeRangeStartFormat: timeRangeStartFormat,
+  eventTimeRangeEndFormat: timeRangeEndFormat,
 
   timeGutterFormat: 'LT',
 

--- a/src/localizers/moment.js
+++ b/src/localizers/moment.js
@@ -16,10 +16,10 @@ let timeRangeFormat = ({ start, end }, culture, local)=>
     ' — ' + local.format(end, inSame12Hr(start, end) ? 'h:mm' : 'h:mma', culture)
 
 let timeRangeStartFormat = ({ start, end }, culture, local)=>
-  local.format(start, 'h:mmtt', culture) +' — '
+  local.format(start, 'h:mma', culture) +' — '
 
 let timeRangeEndFormat = ({ start, end }, culture, local)=>
-  ' — ' + local.format(end, 'h:mmtt', culture)
+  ' — ' + local.format(end, 'h:mma', culture)
 
 let weekRangeFormat = ({ start, end }, culture, local)=>
   local.format(start, 'MMM DD', culture) +

--- a/src/localizers/oldGlobalize.js
+++ b/src/localizers/oldGlobalize.js
@@ -9,6 +9,12 @@ let timeRangeFormat = ({ start, end }, culture, local)=>
   local.format(start, 't', culture) +
     ' — ' + local.format(end, 't', culture)
 
+let timeRangeStartFormat = ({ start, end }, culture, local)=>
+  local.format(start, 't', culture) + ' — '
+
+let timeRangeEndFormat = ({ start, end }, culture, local)=>
+  ' — ' + local.format(end, 't', culture)
+
 let weekRangeFormat = ({ start, end }, culture, local)=>
   local.format(start, 'MMM dd', culture) +
     ' - ' + local.format(end, dates.eq(start, end, 'month') ? 'dd' : 'MMM dd', culture)
@@ -24,6 +30,8 @@ export let formats = {
 
   selectRangeFormat: timeRangeFormat,
   eventTimeRangeFormat: timeRangeFormat,
+  eventTimeRangeStartFormat: timeRangeStartFormat,
+  eventTimeRangeEndFormat: timeRangeEndFormat,
 
   timeGutterFormat: 't',
 


### PR DESCRIPTION
Events that went from say 8PM to 2AM the next day were being listed as all-day events.

This change changes them to this formatting.
![screen shot 2016-02-16 at 12 15 47 pm](https://cloud.githubusercontent.com/assets/53399/13089786/2d508bb6-d4a7-11e5-8720-15b63270ffee.png)![screen shot 2016-02-16 at 12 16 02 pm](https://cloud.githubusercontent.com/assets/53399/13089787/2d510a64-d4a7-11e5-91cc-c987b97e9d7f.png)

Normal all day events (that start and end on date-only dates or have the allDayAccessor set) still display as all day events. Though as a side effect events which span multiple days and have a defined start or end time will be formatted like this, instead of the middle portion that spans the whole day being put in the all day section. This is because the code would need to be significantly rewritten to put just the all-day portions in the all-day header.

![screen shot 2016-02-16 at 12 16 36 pm](https://cloud.githubusercontent.com/assets/53399/13089785/2d508daa-d4a7-11e5-9331-41f87e34cef9.png)![screen shot 2016-02-16 at 12 16 20 pm](https://cloud.githubusercontent.com/assets/53399/13089784/2d4ffcb4-d4a7-11e5-8bf4-a9b4ac8dd60d.png)