### PR TITLE
Do not show view toolbar if only one view is specified

### DIFF
--- a/src/Toolbar.jsx
+++ b/src/Toolbar.jsx
@@ -41,14 +41,7 @@ let Toolbar = React.createClass({
 
         <span className='rbc-btn-group'>
           {
-            viewNames.map(name =>
-              <button type='button' key={name}
-                className={cn({'rbc-active': view === name})}
-                onClick={this.view.bind(null, name)}
-              >
-                {messages[name]}
-              </button>
-            )
+            this.viewNamesGroup(messages)
           }
         </span>
       </div>
@@ -61,6 +54,25 @@ let Toolbar = React.createClass({
 
   view(view){
     this.props.onViewChange(view)
+  },
+
+  viewNamesGroup(messages) {
+    let component = null
+    let viewNames = this.props.views
+    const view = this.props.view
+
+    if (viewNames.length > 1) {
+      return (
+        viewNames.map(name =>
+          <button type='button' key={name}
+            className={cn({'rbc-active': view === name})}
+            onClick={this.view.bind(null, name)}
+          >
+            {messages[name]}
+          </button>
+        )
+      )
+    }
   }
 });
 


### PR DESCRIPTION
Hi!

I was wondering if it would make sense not to display the views on the right side, in the toolbar if you pass only one view. Let's say you only want a monthly view, it doesn't really male sense to show only a month tab, not doing anything when clicking on it, and it doesn't show any valuable information.