### PR TITLE
Fixed Month and Week Rendering Bug

### DIFF
--- a/src/utils/eventLevels.js
+++ b/src/utils/eventLevels.js
@@ -8,7 +8,7 @@ export function eventSegments(event, first, last, { startAccessor, endAccessor, 
 
   let span = dates.diff(start, end, 'day');
 
-  span = Math.floor(Math.max(Math.min(span, slots), 1));
+  span = Math.floor(Math.max(span, 1));
 
   let padding = Math.floor(dates.diff(first, start, 'day'));
 


### PR DESCRIPTION
Fixes #36 

@jquense I noticed in dade2b9 you added the slots variable and in 8ad4ee7 you modified the span variable. Upon debugging the issue, I noticed that the span was getting the correct calculation (which is the beginning of the start date to the end of the end date), but slots was retrieving 6. Can you please describe exactly what those commits were trying to fix? I really like your component and we are currently using it in a project so I would be glad to help you solve this issue!