### PR TITLE
Update React peerDependency to allow working with v15.x (15.0.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "release": "release"
   },
   "peerDependencies": {
-    "react": "^0.14.0-beta1",
-    "react-dom": "^0.14.0-beta3"
+    "react": "^0.14.0 || ^15.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0"
   },
   "devDependencies": {
     "autoprefixer-core": "^5.2.1",


### PR DESCRIPTION
Current issue:

    $ npm i --save react@15
    npm ERR! peerinvalid The package react@15.0.1 does not satisfy its siblings' 
    peerDependencies requirements!
    npm ERR! peerinvalid Peer react-big-calendar@0.9.8 wants react@^0.14.0-beta1