### PR TITLE
Fix first day of the week evaluation when using Globalize

### DIFF
--- a/examples/demos/cultures.js
+++ b/examples/demos/cultures.js
@@ -10,7 +10,7 @@ require('globalize/lib/cultures/globalize.culture.ar-AE');
 let Cultures = React.createClass({
 
   getInitialState(){
-    return { culture: 'fr' }
+    return { culture: 'en-GB' }
   },
 
   render(){

--- a/examples/demos/cultures.js
+++ b/examples/demos/cultures.js
@@ -10,7 +10,7 @@ require('globalize/lib/cultures/globalize.culture.ar-AE');
 let Cultures = React.createClass({
 
   getInitialState(){
-    return { culture: 'en-GB' }
+    return { culture: 'fr' }
   },
 
   render(){

--- a/package.json
+++ b/package.json
@@ -6,12 +6,6 @@
   "repository": "intljusticemission/react-big-calendar",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "lib/*",
-    "LICENSE",
-    "README.md",
-    "CHANGELOG.md"
-  ],
   "keywords": [
     "scheduler",
     "react-component",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "files": [
-    "lib/",
+    "lib/*",
     "LICENSE",
     "README.md",
     "CHANGELOG.md"

--- a/src/localizers/globalize.js
+++ b/src/localizers/globalize.js
@@ -43,11 +43,12 @@ export default function(globalize) {
   // method of getting first day of week.
   function firstOfWeek(culture) {
     try {
-        const days = ['sun', 'mon', 'tue', 'wed', 'thur', 'fri', 'sat'];
+        const days = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
         const cldr = locale(culture).cldr;
         const territory = cldr.attributes.territory;
         const weekData = cldr.get('supplemental').weekData;
         const firstDay = weekData.firstDay[territory || '001'];
+        console.log("FIRST OF WEEK", days.indexOf(firstDay));
         return days.indexOf(firstDay);
     } catch (e) {
         console.error("Could not use suplemental", e)

--- a/src/localizers/globalize.js
+++ b/src/localizers/globalize.js
@@ -50,6 +50,7 @@ export default function(globalize) {
         const firstDay = weekData.firstDay[territory || '001'];
         return days.indexOf(firstDay);
     } catch (e) {
+        console.error("Could not use suplemental", e)
         // maybe cldr supplemental is not loaded? revert to original method
         const date = new Date();
         //cldr-data doesn't seem to be zero based

--- a/src/localizers/globalize.js
+++ b/src/localizers/globalize.js
@@ -1,6 +1,6 @@
 import dates from '../utils/dates';
 import oldGlobalize from './oldGlobalize';
-import invariant from 'invariant';
+import warning from 'warning';
 import { set } from '../formats';
 import { set as setLocalizer } from '../localizer';
 
@@ -51,7 +51,7 @@ export default function(globalize) {
         const firstDay = weekData.firstDay[territory || '001'];
         return days.indexOf(firstDay);
     } catch (e) {
-        invariant(true,
+        warning(true,
             `Failed to accurately determine first day of the week.
             Is supplemental data loaded into CLDR?`);
         // maybe cldr supplemental is not loaded? revert to original method

--- a/src/localizers/globalize.js
+++ b/src/localizers/globalize.js
@@ -48,10 +48,9 @@ export default function(globalize) {
         const territory = cldr.attributes.territory;
         const weekData = cldr.get('supplemental').weekData;
         const firstDay = weekData.firstDay[territory || '001'];
-        console.log("FIRST OF WEEK", days.indexOf(firstDay));
         return days.indexOf(firstDay);
     } catch (e) {
-        console.error("Could not use suplemental", e)
+        console.warn('Failed to accurately determine first day of the week. Is supplemental data loaded into CLDR?', e);
         // maybe cldr supplemental is not loaded? revert to original method
         const date = new Date();
         //cldr-data doesn't seem to be zero based

--- a/src/localizers/globalize.js
+++ b/src/localizers/globalize.js
@@ -1,5 +1,6 @@
 import dates from '../utils/dates';
 import oldGlobalize from './oldGlobalize';
+import invariant from 'invariant';
 import { set } from '../formats';
 import { set as setLocalizer } from '../localizer';
 
@@ -50,7 +51,9 @@ export default function(globalize) {
         const firstDay = weekData.firstDay[territory || '001'];
         return days.indexOf(firstDay);
     } catch (e) {
-        console.warn('Failed to accurately determine first day of the week. Is supplemental data loaded into CLDR?', e);
+        invariant(true,
+            `Failed to accurately determine first day of the week.
+            Is supplemental data loaded into CLDR?`);
         // maybe cldr supplemental is not loaded? revert to original method
         const date = new Date();
         //cldr-data doesn't seem to be zero based


### PR DESCRIPTION
This PR resolves issue #78  where the evaluation of first day of the week fails on every Sunday (for en-GB locale at least). On Sundays the first day of the week was evaluated as Saturday instead of Monday. 
The PR is an update to the ```firstOfWeek``` function in ```src/localizers/globalize.js``` and it uses the CLDR supplemental data to correctly retrieve the first day of the week. Failing to use this method, there is a fallback to using the original Math based approach to determine the first day. 

Another change is an update to packages.json file, which removes the ```files``` key. The problem with that was that having files there, meant any ```npm install``` from github resulted in JUST those files listed, and none of the src files. Apparently this is a common problem (also exists in projects like react-router etc.). 