### PR TITLE
revert back package.json to include the files key

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
   "repository": "intljusticemission/react-big-calendar",
   "license": "MIT",
   "main": "lib/index.js",
+  "files": [
+    "lib/",
+    "LICENSE",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "keywords": [
     "scheduler",
     "react-component",


### PR DESCRIPTION
My previous PR removed files from packages.json as it was preventing the 
installation of the package from github. Basically only the files included were 
pulled from git when going that route. Removing files caused all files to be 
pulled from git when doing npm install. This however is also undesirable as 
you'd only want distributable files going to the npm process when installing 
from npm.

So, in short, it should be your decision how to proceed with this, not mine, 
so I'm reverting the packages file to how it was. If stays as is, it won't be 
possible to install this package from github but that is not necessarily a bad 
thing. One can always fork, update packages, and use the fork to install until 
dev is over. As well, there are probably better options to cater both to github 
and npm installs.