### PR TITLE
allow replacing components for day, week, month and agenda, not just event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+.idea

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -286,12 +286,13 @@ let Calendar = React.createClass({
       agenda: PropTypes.shape({
         date: elementType,
         time: elementType,
-        event: elementType
+        event: elementType,
+        component: PropTypes.element
       }),
 
-      day: PropTypes.shape({ event: elementType }),
-      week: PropTypes.shape({ event: elementType }),
-      month: PropTypes.shape({ event: elementType })
+      day: PropTypes.shape({ event: elementType, component: PropTypes.element }),
+      week: PropTypes.shape({ event: elementType, component: PropTypes.element }),
+      month: PropTypes.shape({ event: elementType, component: PropTypes.element })
     }),
 
     /**
@@ -338,7 +339,7 @@ let Calendar = React.createClass({
 
     formats = defaultFormats(formats)
 
-    let View = VIEWS[view];
+    let View = this.props[view].component || VIEWS[view];
     let names = viewNames(this.props.views)
 
     let elementProps = omit(this.props, Object.keys(Calendar.propTypes))

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -339,7 +339,8 @@ let Calendar = React.createClass({
 
     formats = defaultFormats(formats)
 
-    let View = (this.props[view] && this.props[view].component) || VIEWS[view];
+    const viewComponent = (components && components[view] && components[view].component) || VIEWS[view];
+    let View = viewComponent;
     let names = viewNames(this.props.views)
 
     let elementProps = omit(this.props, Object.keys(Calendar.propTypes))

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -339,7 +339,7 @@ let Calendar = React.createClass({
 
     formats = defaultFormats(formats)
 
-    let View = this.props[view].component || VIEWS[view];
+    let View = (this.props[view] && this.props[view].component) || VIEWS[view];
     let names = viewNames(this.props.views)
 
     let elementProps = omit(this.props, Object.keys(Calendar.propTypes))


### PR DESCRIPTION
This allows for extreme customization.  For instance, a week view for a
sign-up sheet where only 2 days are allowed should be able to display just those 2 days.  Another example is implementing a special grid that blocks off unavailable times using a different color.

Currently, the only way to do this is to extend Calendar, copy/paste the render() method, replace the view in question, and that's not very DRY.