### PR TITLE
Fix full week span event being truncated on last day of the week.

### DIFF
--- a/src/TimeGrid.jsx
+++ b/src/TimeGrid.jsx
@@ -93,7 +93,9 @@ let TimeGrid = React.createClass({
 
     allDayEvents.sort((a, b) => sortEvents(a, b, this.props))
 
-    let segments = allDayEvents.map(evt => eventSegments(evt, start, end, this.props))
+    let {first, last} = endOfRange(range);
+
+    let segments = allDayEvents.map(evt => eventSegments(evt, first, last, this.props))
     let { levels } = eventLevels(segments)
 
     return (


### PR DESCRIPTION
This should fix issue #36 (the week view issue).

**Note**:  I'm not sure of the potential collateral this fix could bring up. I manually tested that it works for my use cases (month and week views) so there may not be any. Should we start adding functional tests?

**Second Note**: I needed to update some unrelated code because the `npm test` command was failing. There was a lint error.