### PR TITLE
allow to pass custom views

### DIFF
--- a/examples/App.js
+++ b/examples/App.js
@@ -29,7 +29,8 @@ const Example = React.createClass({
       selectable: require('./demos/selectable'),
       cultures: require('./demos/cultures'),
       popup: require('./demos/popup'),
-      rendering: require('./demos/rendering')
+      rendering: require('./demos/rendering'),
+      customView: require('./demos/customView'),
     }[selected];
 
     return (
@@ -70,6 +71,9 @@ const Example = React.createClass({
               </li>
               <li className={cn({active: selected === 'rendering' })}>
                 <a href='#' onClick={this.select.bind(null, 'rendering')}>Custom rendering</a>
+              </li>
+              <li className={cn({active: selected === 'customView' })}>
+                <a href='#' onClick={this.select.bind(null, 'customView')}>Custom View</a>
               </li>
             </ul>
           </aside>

--- a/examples/App.js
+++ b/examples/App.js
@@ -72,9 +72,11 @@ const Example = React.createClass({
               <li className={cn({active: selected === 'rendering' })}>
                 <a href='#' onClick={this.select.bind(null, 'rendering')}>Custom rendering</a>
               </li>
+              {/* temporary hide link to documentation
               <li className={cn({active: selected === 'customView' })}>
                 <a href='#' onClick={this.select.bind(null, 'customView')}>Custom View</a>
               </li>
+              */}
             </ul>
           </aside>
           <div className='example'>

--- a/examples/demos/customView.js
+++ b/examples/demos/customView.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import BigCalendar from '../../src/index';
+import events from '../events';
+import { navigate } from 'react-big-calendar/utils/constants';
+import Week from 'react-big-calendar/Week';
+import dates from 'react-big-calendar/utils/dates';
+import localizer from 'react-big-calendar/localizer';
+import TimeGrid from 'react-big-calendar/TimeGrid';
+
+class MyWeek extends Week {
+  render() {
+    let { date } = this.props;
+    let { start, end } = MyWeek.range(date, this.props);
+
+    return (
+      <TimeGrid {...this.props} start={start} end={end} eventOffset={15} />
+    );
+  }
+}
+
+MyWeek.navigate = (date, action)=>{
+  switch (action){
+    case navigate.PREVIOUS:
+      return dates.add(date, -1, 'week');
+
+    case navigate.NEXT:
+      return dates.add(date, 1, 'week')
+
+    default:
+      return date;
+  }
+}
+
+MyWeek.range = (date, { culture }) => {
+  let firstOfWeek = localizer.startOfWeek(culture);
+  let start = dates.startOf(date, 'week', firstOfWeek);
+  let end = dates.endOf(date, 'week', firstOfWeek);
+
+  if (firstOfWeek === 1) {
+    end = dates.subtract(end, 2, 'day');
+  } else {
+    start = dates.add(start, 1, 'day');
+    end = dates.subtract(end, 1, 'day');
+  }
+
+  return { start, end };
+}
+
+
+
+
+let CustomView = React.createClass({
+  render(){
+    return (
+      <div>
+        <BigCalendar
+          events={events}
+          defaultDate={new Date(2015, 3, 1)}
+          views={{ month: true, week: MyWeek }}
+          test="io"
+        />
+      </div>
+    )
+  }
+})
+
+export default CustomView;

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -19,6 +19,8 @@ import Toolbar from './Toolbar';
 
 import omit from 'lodash/object/omit';
 import defaults from 'lodash/object/defaults';
+import transform from 'lodash/object/transform';
+import mapValues from 'lodash/object/mapValues';
 
 function viewNames(_views){
   return !Array.isArray(_views) ? Object.keys(_views) : _views
@@ -325,6 +327,32 @@ let Calendar = React.createClass({
     };
   },
 
+  getViews() {
+    const views = this.props.views;
+
+    if (Array.isArray(views)) {
+      return transform(views, (obj, name) => obj[name] = VIEWS[name], {});
+    }
+
+    if (typeof views === 'object') {
+      return mapValues(views, (value, key) => {
+        if (value === true) {
+          return VIEWS[key];
+        }
+
+        return value;
+      });
+    }
+
+    return VIEWS;
+  },
+
+  getView() {
+    const views = this.getViews();
+
+    return views[this.props.view];
+  },
+
   render() {
     let {
         view, toolbar, events
@@ -338,7 +366,7 @@ let Calendar = React.createClass({
 
     formats = defaultFormats(formats)
 
-    let View = VIEWS[view];
+    let View = this.getView();
     let names = viewNames(this.props.views)
 
     let elementProps = omit(this.props, Object.keys(Calendar.propTypes))


### PR DESCRIPTION
Fixes #97 

Do follow the comments of #93 

I did not manage to set the propType good in `src/utils/propTypes.js`, can you help me with that ? 

Doing this, I tried to extends the `Week` view, but it was not as easy as I though, so I had to reimplement a full view. The fact is that we can not extends the `range` method. I do not search very well for that as it is not the purpose of this code, but it might be a good future evolution.