### PR TITLE
Fix dayHeaderFormat when using Moment.js

### DIFF
--- a/src/localizers/moment.js
+++ b/src/localizers/moment.js
@@ -30,7 +30,7 @@ export let formats = {
   timeGutterFormat: 'LT',
 
   monthHeaderFormat: 'MMMM YYYY',
-  dayHeaderFormat: 'dddd MMM dd',
+  dayHeaderFormat: 'dddd MMM DD',
   dayRangeHeaderFormat: weekRangeFormat,
   agendaHeaderFormat: dateRangeFormat,
 


### PR DESCRIPTION
In Globalize `dd` is the numeric day of the month but in Moment it's the [short weekday](http://momentjs.com/docs/#/displaying/format/), meaning that the day header was rendered as 'Monday May Mo' instead of 'Monday May 01' when using Moment.