### PR TITLE
Add style key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "repository": "intljusticemission/react-big-calendar",
   "license": "MIT",
   "main": "lib/index.js",
+  "style": "lib/css/react-big-calendar.css",
   "files": [
     "lib/",
     "LICENSE",


### PR DESCRIPTION
This PR enables npm-based css imports for libraries like [npm-css](https://github.com/defunctzombie/npm-css), [postcss-import](https://github.com/postcss/postcss-import#postcss-import), [rework-import](https://github.com/reworkcss/rework-npm) so you can write:
```css
@import "react-big-calendar";
```
instead of 
```css
@import "react-big-calendar/lib/css/react-big-calendar.css";
```

r? @jquense 