### PR TITLE
allow a custom popup component and use the right event component in default popup

### DIFF
--- a/src/Month.jsx
+++ b/src/Month.jsx
@@ -287,6 +287,7 @@ let MonthView = React.createClass({
 
   _renderOverlay(){
     let overlay = (this.state && this.state.overlay) || {};
+    let { components } = this.props;
 
     return (
       <Overlay
@@ -298,6 +299,7 @@ let MonthView = React.createClass({
       >
         <Popup
           {...this.props}
+          eventComponent={components.event}
           position={overlay.position}
           events={overlay.events}
           slotStart={overlay.date}


### PR DESCRIPTION
cc @jquense 

In the _Show X More_ popup, it was trying to pull `eventComponent` from props but that was never passed in.  Lets make sure it gets passed in.