### PR TITLE
Documentation: 'step' prop

### DIFF
--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -158,6 +158,11 @@ let Calendar = React.createClass({
     selectable: PropTypes.bool,
 
     /**
+     * Determines the selectable time increments in week and day views
+     */
+    step: React.PropTypes.number,
+
+    /**
      * switch the calendar to a `right-to-left` read direction.
      */
     rtl: PropTypes.bool,
@@ -319,6 +324,7 @@ let Calendar = React.createClass({
       view: views.MONTH,
       views: [views.MONTH, views.WEEK, views.DAY, views.AGENDA],
       date: now,
+      step: 30,
 
       titleAccessor: 'title',
       allDayAccessor: 'allDay',


### PR DESCRIPTION
Just adds the `step` prop from `src/TimeGrid` to the propTypes of `src/Calendar` so that it appears in the documentation - it's a super useful prop to know about. Sets a default value of 30, much like in `src/TimeGrid` since half hour increments seem to be the default elsewhere in the code.