### PR TITLE
Added scrollTime prop like in FullCalendar

### DIFF
--- a/examples/demos/selectable.js
+++ b/examples/demos/selectable.js
@@ -14,6 +14,7 @@ let Selectable = React.createClass({
           selectable
           events={events}
           defaultView='week'
+          scrollToTime={new Date(1970, 1, 1, 17)}
           defaultDate={new Date(2015, 3, 1)}
           onSelectEvent={event => alert(event.title)}
           onSelectSlot={(slotInfo) => alert(

--- a/examples/demos/selectable.js
+++ b/examples/demos/selectable.js
@@ -14,7 +14,7 @@ let Selectable = React.createClass({
           selectable
           events={events}
           defaultView='week'
-          scrollToTime={new Date(1970, 1, 1, 17)}
+          scrollToTime={new Date(1970, 1, 1, 6)}
           defaultDate={new Date(2015, 3, 1)}
           onSelectEvent={event => alert(event.title)}
           onSelectSlot={(slotInfo) => alert(

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -218,9 +218,14 @@ let Calendar = React.createClass({
     min: PropTypes.instanceOf(Date),
 
     /**
-     * Constrains the maximum _time_ of the Day and Week views..
+     * Constrains the maximum _time_ of the Day and Week views.
      */
     max: PropTypes.instanceOf(Date),
+
+    /**
+     * Determines how far down the scroll pane is initially scrolled down.
+     */
+    scrollToTime: PropTypes.instanceOf(Date),
 
     /**
      * Localizer specific formats, tell the Calendar how to format and display dates.

--- a/src/TimeGrid.jsx
+++ b/src/TimeGrid.jsx
@@ -64,7 +64,7 @@ export default class TimeGrid extends Component {
 
   componentWillMount() {
     this._gutters = [];
-    this.adjustScroll();
+    this.calculateScroll();
   }
 
   componentDidMount() {
@@ -91,10 +91,10 @@ export default class TimeGrid extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { start, scrollTop } = this.props;
+    const { start, scrollToTime } = this.props;
     // When paginating, reset scroll
-    if (!dates.eq(nextProps.start, start) || nextProps.scrollTop !== scrollTop) {
-      this.adjustScroll();
+    if (!dates.eq(nextProps.start, start) || nextProps.scrollToTime !== scrollToTime) {
+      this.calculateScroll();
     }
   }
 
@@ -295,7 +295,7 @@ export default class TimeGrid extends Component {
     }
   }
 
-  adjustScroll() {
+  calculateScroll() {
     const { min, max, scrollToTime } = this.props;
 
     const diffMillis = scrollToTime - dates.startOf(scrollToTime, 'day');

--- a/src/TimeGrid.jsx
+++ b/src/TimeGrid.jsx
@@ -73,6 +73,7 @@ export default class TimeGrid extends Component {
     if (this.props.width == null) {
       this.measureGutter()
     }
+    this.applyScroll();
   }
 
   componentDidUpdate() {
@@ -80,13 +81,7 @@ export default class TimeGrid extends Component {
       this.measureGutter()
     }
 
-    if (this._scrollRatio) {
-      const { content } = this.refs;
-      content.scrollTop = content.scrollHeight * this._scrollRatio;
-      // Only do this once
-      this._scrollRatio = null;
-    }
-
+    this.applyScroll();
     //this.checkOverflow()
   }
 
@@ -295,6 +290,15 @@ export default class TimeGrid extends Component {
     }
   }
 
+  applyScroll() {
+    if (this._scrollRatio) {
+      const { content } = this.refs;
+      content.scrollTop = content.scrollHeight * this._scrollRatio;
+      // Only do this once
+      this._scrollRatio = null;
+    }
+  }
+
   calculateScroll() {
     const { min, max, scrollToTime } = this.props;
 
@@ -309,7 +313,7 @@ export default class TimeGrid extends Component {
 
     let isOverflowing = this.refs.content.scrollHeight > this.refs.content.clientHeight;
 
-    if (this.setState.isOverflowing !== isOverflowing) {
+    if (this.state.isOverflowing !== isOverflowing) {
       this._updatingOverflow = true;
       this.setState({ isOverflowing }, () => {
         this._updatingOverflow = false;


### PR DESCRIPTION
I added a new prop scrollTime so that the TimeGrid view is initially scrolled down to a specified hour on every mount or change of prev/next week. Let me know if I need to add any checks!

Original prop: http://fullcalendar.io/docs/agenda/scrollTime/

Takes a Date object, which I don't find really useful (a moment.duration would be more suitable, or an amount in millis, but I get how this is moment-agnostic) but props `min` and `max` used that too so I figured I'd use the same method :)