### PR TITLE
Added TypeScript Definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
   "license": "MIT",
   "main": "lib/index.js",
   "style": "lib/css/react-big-calendar.css",
-  "typings": "lib/react-big-calendar.d.ts",
+  "typings": "typings/react-big-calendar.d.ts",
   "files": [
     "lib/",
+    "typings/",
     "LICENSE",
     "README.md",
     "CHANGELOG.md"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "style": "lib/css/react-big-calendar.css",
+  "typings": "lib/react-big-calendar.d.ts",
   "files": [
     "lib/",
     "LICENSE",

--- a/typings/react-big-calendar.d.ts
+++ b/typings/react-big-calendar.d.ts
@@ -1,0 +1,46 @@
+// Type definitions for React Big Calendar v0.10.X (react-big-calendar)
+// Project: https://github.com/intljusticemission/react-big-calendar
+// Definitions by: Piotr Witek <piotrek.witek@gmail.com> (http://piotrwitek.github.io)
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'react-big-calendar' {
+  import * as React from 'react';
+
+  type stringOrDate = string | Date;
+
+  interface Props {
+    date?: stringOrDate;
+    view?: string;
+    events?: Object[];
+    onNavigate?: Function;
+    onView?: Function;
+    onSelectSlot?: (slotInfo: { start: stringOrDate, end: stringOrDate, slots: Date[] | string[] }) => void;
+    onSelectEvent?: (event: Object) => void;
+    onSelecting?: (slotInfo: { start: stringOrDate, end: stringOrDate }) => boolean;
+    views?: Object;
+    toolbar?: boolean;
+    popup?: boolean;
+    popupOffset?: number | { x: number, y: number };
+    selectable?: boolean;
+    step?: number;
+    rtl?: boolean;
+    eventPropGetter?: (event: Object, start: stringOrDate, end: stringOrDate, isSelected: boolean) => void;
+    titleAccessor?: string;
+    allDayAccessor?: boolean;
+    startAccessor?: stringOrDate;
+    endAccessor?: stringOrDate;
+    min?: stringOrDate;
+    max?: stringOrDate;
+    scrollToTime?: stringOrDate;
+    formats?: Object;
+    components?: Object;
+    messages?: Object;
+  }
+
+  export class BigCalendar extends React.Component<Props, any> {
+    static momentLocalizer(momentInstance: Object): void;
+    static globalizeLocalizer(globalizeInstance: Object): void;
+  }
+
+  export default BigCalendar;
+}


### PR DESCRIPTION
Hello,
Today my friend asked me to help him create TypeScript Definition for this library:

I have created typings with all the props described in the Docs. I hope it will be useful to devs who are using React together with TypeScript like me, which is highly beneficial for props validation and autocomplete of the entire API with parameter types. Even pure JS devs can benefit from it using IDE that can parse TypeScript declaration (Visual Studio, VS Code, WebStorm).

If you want to see how TypeScript integrate with React please check my Starter-Kit project, it's very clean and simple to follow and grasp (using ES6):
- https://github.com/piotrwitek/react-ts-jspm-starter-kit

In this PR I have also included typings property for package.json, so developers installing this package can have declarations added to their project automatically from node_modules while importing/requiring packages (TypeScript can do it :smile: )

> Typings property explained: https://www.typescriptlang.org/docs/handbook/typings-for-npm-packages.html

![image](https://cloud.githubusercontent.com/assets/739075/16923435/8dac99be-4d1a-11e6-9a49-ca9b3a835782.png)

