### PR TITLE
Pass custom dates for a given month

### DIFF
--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -228,6 +228,12 @@ let Calendar = React.createClass({
     scrollToTime: PropTypes.instanceOf(Date),
 
     /**
+     * Pass Custom Dates to Month. This will be useful, when you want to display something like a fiscal calendar
+     * Where a month in June 2015 can have 4 weeks with weeks which are in May 2015 and April 2015.
+     */
+     customDatesForMonth: PropTypes.func,
+
+    /**
      * Localizer specific formats, tell the Calendar how to format and display dates.
      */
     formats: PropTypes.shape({

--- a/src/Month.jsx
+++ b/src/Month.jsx
@@ -108,8 +108,8 @@ let MonthView = React.createClass({
 
   render() {
     var { date, culture, weekdayFormat } = this.props
-      , month = dates.visibleDays(date, culture)
-      , weeks  = chunk(month, 7);
+    var month = this.getDates(date, culture)
+    var weeks  = chunk(month, 7);
 
     let measure = this.state.needLimitMeasure
 
@@ -130,6 +130,15 @@ let MonthView = React.createClass({
         }
       </div>
     )
+  },
+
+  getDates(date, culture) {
+    if(this.props.customDatesForMonth !== undefined) {
+      return this.props.customDatesForMonth(this, date)
+    }
+    else {
+      return dates.visibleDays(date, culture)
+    }
   },
 
   renderWeek(week, weekIdx, content) {


### PR DESCRIPTION
Hey,

For a given month, I needed the ability to show different dates which are not necessarily in that month. This will be useful to display fiscal calendars like the 4-5-4 etc.

So, I added a way to pass in a function as a prop, where I can pass an array of date objects which I want.

Check it out and let me know if this can be merged and also if any documentation that I need to provide.