### PR TITLE
fix - wrong end time label in agenda

### DIFF
--- a/src/Agenda.jsx
+++ b/src/Agenda.jsx
@@ -138,7 +138,7 @@ let Agenda = React.createClass({
         label = localizer.format(start, this.props.agendaTimeFormat, culture)
       }
       else if (dates.eq(day, end, 'day')){
-        label = localizer.format(start, this.props.agendaTimeFormat, culture)
+        label = localizer.format(end, this.props.agendaTimeFormat, culture)
       }
     }
 


### PR DESCRIPTION
   e.g.
    'start': new Date(2015, 3, 7, 13, 15),
    'end': new Date(2015, 3, 10, 17, 30)
shows 
<< 1:15 pm  // time from start date
instead of 
<< 17:30 pm