### PR TITLE
Add an indicator that represents the current time

### DIFF
--- a/src/TimeGrid.jsx
+++ b/src/TimeGrid.jsx
@@ -150,7 +150,7 @@ export default class TimeGrid extends Component {
           this.renderHeader(range, segments, width)
         }
         <div ref='content' className='rbc-time-content'>
-          <div className='rbc-current-time-indicator' ref='timeIndicator'></div>
+          <div ref='timeIndicator' className='rbc-current-time-indicator'></div>
           <TimeColumn
             {...this.props}
             showLabels
@@ -344,8 +344,10 @@ export default class TimeGrid extends Component {
     if (timeGutter) {
       const pixelHeight = timeGutter.offsetHeight;
       const offset = Math.floor(factor * pixelHeight);
+      const timeIndicator = this.refs.timeIndicator;
 
-      this.refs.timeIndicator.style.top = offset + 'px';
+      timeIndicator.style.left = timeGutter.offsetWidth + 'px';
+      timeIndicator.style.top = offset + 'px';
     }
   }
 

--- a/src/TimeGrid.jsx
+++ b/src/TimeGrid.jsx
@@ -74,6 +74,17 @@ export default class TimeGrid extends Component {
       this.measureGutter()
     }
     this.applyScroll();
+
+    this.positionTimeIndicator();
+
+    // Update the position of the time indicator every minute
+    this._timeIndicatorInterval = window.setInterval(() => {
+      this.positionTimeIndicator();
+    }, 60000);
+  }
+
+  componentWillUnmount() {
+    window.clearInterval(this._timeIndicatorInterval);
   }
 
   componentDidUpdate() {
@@ -82,6 +93,7 @@ export default class TimeGrid extends Component {
     }
 
     this.applyScroll();
+    this.positionTimeIndicator();
     //this.checkOverflow()
   }
 
@@ -138,6 +150,7 @@ export default class TimeGrid extends Component {
           this.renderHeader(range, segments, width)
         }
         <div ref='content' className='rbc-time-content'>
+          <div className='rbc-current-time-indicator' ref='timeIndicator'></div>
           <TimeColumn
             {...this.props}
             showLabels
@@ -318,6 +331,21 @@ export default class TimeGrid extends Component {
       this.setState({ isOverflowing }, () => {
         this._updatingOverflow = false;
       })
+    }
+  }
+
+  positionTimeIndicator() {
+    const secondsGrid = dates.diff(this.props.max, this.props.min, 'seconds');
+    const secondsPassed = dates.diff(new Date(), this.props.min, 'seconds');
+
+    const factor = secondsPassed / secondsGrid;
+    const timeGutter = this._gutters[this._gutters.length - 1];
+
+    if (timeGutter) {
+      const pixelHeight = timeGutter.offsetHeight;
+      const offset = Math.floor(factor * pixelHeight);
+
+      this.refs.timeIndicator.style.top = offset + 'px';
     }
   }
 

--- a/src/TimeGrid.jsx
+++ b/src/TimeGrid.jsx
@@ -335,19 +335,25 @@ export default class TimeGrid extends Component {
   }
 
   positionTimeIndicator() {
-    const secondsGrid = dates.diff(this.props.max, this.props.min, 'seconds');
-    const secondsPassed = dates.diff(new Date(), this.props.min, 'seconds');
+    const {min, max} = this.props
+    const now = new Date();
 
+    const secondsGrid = dates.diff(max, min, 'seconds');
+    const secondsPassed = dates.diff(now, min, 'seconds');
+
+    const timeIndicator = this.refs.timeIndicator;
     const factor = secondsPassed / secondsGrid;
     const timeGutter = this._gutters[this._gutters.length - 1];
 
-    if (timeGutter) {
+    if (timeGutter && now >= min && now <= max) {
       const pixelHeight = timeGutter.offsetHeight;
       const offset = Math.floor(factor * pixelHeight);
-      const timeIndicator = this.refs.timeIndicator;
 
+      timeIndicator.style.display = 'block';
       timeIndicator.style.left = timeGutter.offsetWidth + 'px';
       timeIndicator.style.top = offset + 'px';
+    } else {
+      timeIndicator.style.display = 'none';
     }
   }
 

--- a/src/TimeGrid.jsx
+++ b/src/TimeGrid.jsx
@@ -76,15 +76,11 @@ export default class TimeGrid extends Component {
     this.applyScroll();
 
     this.positionTimeIndicator();
-
-    // Update the position of the time indicator every minute
-    this._timeIndicatorInterval = window.setInterval(() => {
-      this.positionTimeIndicator();
-    }, 60000);
+    this.triggerTimeIndicatorUpdate();
   }
 
   componentWillUnmount() {
-    window.clearInterval(this._timeIndicatorInterval);
+    window.clearTimeout(this._timeIndicatorTimeout);
   }
 
   componentDidUpdate() {
@@ -355,6 +351,15 @@ export default class TimeGrid extends Component {
     } else {
       timeIndicator.style.display = 'none';
     }
+  }
+
+  triggerTimeIndicatorUpdate() {
+    // Update the position of the time indicator every minute
+    this._timeIndicatorTimeout = window.setTimeout(() => {
+      this.positionTimeIndicator();
+
+      this.triggerTimeIndicatorUpdate();
+    }, 60000)
   }
 
 }

--- a/src/less/time-column.less
+++ b/src/less/time-column.less
@@ -74,4 +74,5 @@
 
 .rbc-day-slot .rbc-event {
   position: absolute;
+  z-index: 2;
 }

--- a/src/less/time-column.less
+++ b/src/less/time-column.less
@@ -74,5 +74,4 @@
 
 .rbc-day-slot .rbc-event {
   position: absolute;
-  z-index: 2;
 }

--- a/src/less/time-grid.less
+++ b/src/less/time-grid.less
@@ -112,12 +112,14 @@
     display: block;
 
     position: absolute;
-    left: -4px;
-    top: -12px;
+    left: -3px;
+    top: -3px;
 
-    content: '•';
+    content: ' ';
+    background-color: @current-time-color;
 
-    font-size: 18px;
-    color: @current-time-color;
+    border-radius: 50%;
+    width: 8px;
+    height: 8px;
   }
 }

--- a/src/less/time-grid.less
+++ b/src/less/time-grid.less
@@ -107,4 +107,17 @@
 
   background-color: @current-time-color;
   pointer-events: none;
+
+  &::before {
+    display: block;
+
+    position: absolute;
+    left: -4px;
+    top: -12px;
+
+    content: '•';
+
+    font-size: 18px;
+    color: @current-time-color;
+  }
 }

--- a/src/less/time-grid.less
+++ b/src/less/time-grid.less
@@ -78,6 +78,7 @@
   width: 100%;
   border-top: 2px solid @calendar-border;
   overflow-y: auto;
+  position: relative;
 
   > .rbc-time-gutter {
     flex: none;
@@ -95,4 +96,15 @@
   > .rbc-day-slot {
     width: 100%
   }
+}
+
+.rbc-current-time-indicator {
+  position: absolute;
+  z-index: 1;
+
+  width: 100%;
+  height: 1px;
+
+  background-color: @current-time-color;
+  pointer-events: none;
 }

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -23,4 +23,6 @@
 @btn-bg: #fff;
 @btn-border: #ccc;
 
+@current-time-color: #3174ad;
+
 @rbc-css-prefix: rbc-i;

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -23,6 +23,6 @@
 @btn-bg: #fff;
 @btn-border: #ccc;
 
-@current-time-color: #3174ad;
+@current-time-color: #74ad31;
 
 @rbc-css-prefix: rbc-i;


### PR DESCRIPTION
In the week and day view a horizontal line represents the current time.
Apple Calendar and other apps use this concept to provide the current
time as a subtle hint.

The Y position of line is calculated in the TimeGrid by using a date
diff between this.props.max and this.props.min, respectively the
diff between current date and this.props.min.
To convert the result to a pixel value, the height of the time gutter
is used as a reference.
The position of the time indicator is calulated and updated every
minute using setInterval().

Please let me know if you want this feature to be toggled using a
prop.

![screen shot 2016-08-11 at 18 03 50](https://cloud.githubusercontent.com/assets/39352/17595608/fc51e6ea-5fed-11e6-8d5b-eb16db4d28e4.png)