### PR TITLE
Pass 'selected' prop through to All Day Events

### DIFF
--- a/src/TimeGrid.jsx
+++ b/src/TimeGrid.jsx
@@ -202,6 +202,7 @@ export default class TimeGrid extends Component {
         endAccessor={this.props.endAccessor}
         allDayAccessor={this.props.allDayAccessor}
         eventPropGetter={this.props.eventPropGetter}
+        selected={this.props.Selected}
         onSelect={this._selectEvent}
         slots={this._slots}
         key={idx}

--- a/src/TimeGrid.jsx
+++ b/src/TimeGrid.jsx
@@ -202,7 +202,7 @@ export default class TimeGrid extends Component {
         endAccessor={this.props.endAccessor}
         allDayAccessor={this.props.allDayAccessor}
         eventPropGetter={this.props.eventPropGetter}
-        selected={this.props.Selected}
+        selected={this.props.selected}
         onSelect={this._selectEvent}
         slots={this._slots}
         key={idx}


### PR DESCRIPTION
The 'selected' prop was not being passed through to the header Event Rows for All Day events in Month/Week views, which meant that any logic which relied on that prop (special styling for selected events, etc.) wouldn't work. Fix is easy: just make sure to pass that prop down.