### PR TITLE
Days selection fix when using RTL languages

### DIFF
--- a/src/BackgroundCells.jsx
+++ b/src/BackgroundCells.jsx
@@ -11,7 +11,8 @@ class DisplayCells extends React.Component {
   static propTypes = {
     selectable: React.PropTypes.bool,
     onSelect: React.PropTypes.func,
-    slots: React.PropTypes.number
+    slots: React.PropTypes.number,
+    rtl: React.PropTypes.bool
   }
 
   state = { selecting: false }
@@ -62,7 +63,7 @@ class DisplayCells extends React.Component {
     let selector = this._selector = new Selection(this.props.container)
 
     selector.on('selecting', box => {
-      let { slots } = this.props;
+      let { slots, rtl } = this.props;
 
       let startIdx = -1;
       let endIdx = -1;
@@ -78,7 +79,8 @@ class DisplayCells extends React.Component {
             this._initial
           , nodeBox
           , box
-          , slots));
+          , slots
+          , rtl));
       }
 
       this.setState({
@@ -90,10 +92,11 @@ class DisplayCells extends React.Component {
     selector
       .on('click', point => {
         let rowBox = getBoundsForNode(node)
+        let { slots, rtl } = this.props;
 
         if (pointInBox(rowBox, point)) {
           let width = slotWidth(getBoundsForNode(node),  this.props.slots);
-          let currentCell = getCellAtX(rowBox, point.x, width);
+          let currentCell = getCellAtX(rowBox, point.x, width, rtl, slots);
 
           this._selectSlot({
             startIdx: currentCell,

--- a/src/Month.jsx
+++ b/src/Month.jsx
@@ -184,6 +184,7 @@ let MonthView = React.createClass({
 
     return (
     <BackgroundCells
+      rtl={this.props.rtl}
       slots={7}
       onSelectSlot={onSelectSlot}
       container={() => findDOMNode(this)}

--- a/src/TimeGrid.jsx
+++ b/src/TimeGrid.jsx
@@ -259,6 +259,7 @@ export default class TimeGrid extends Component {
           </div>
           <div ref='allDay' className='rbc-allday-cell'>
             <BackgroundCells
+              rtl={this.props.rtl}
               slots={range.length}
               container={()=> this.refs.allDay}
               selectable={this.props.selectable}

--- a/src/utils/selection.js
+++ b/src/utils/selection.js
@@ -11,8 +11,9 @@ export function slotWidth(rowBox, slots){
   return cellWidth
 }
 
-export function getCellAtX(rowBox, x, cellWidth) {
-   return Math.floor((x - rowBox.left) / cellWidth);
+export function getCellAtX(rowBox, x, cellWidth, rtl, slots) {
+   return (rtl ? slots - 1 - Math.floor((x - rowBox.left) / cellWidth) :
+                 Math.floor((x - rowBox.left) / cellWidth));
 }
 
 export function pointInBox(box, { x, y }) {
@@ -22,7 +23,7 @@ export function pointInBox(box, { x, y }) {
    )
 }
 
-export function dateCellSelection(start, rowBox, box, slots){
+export function dateCellSelection(start, rowBox, box, slots, rtl){
   let startIdx = -1;
   let endIdx = -1;
   let lastSlotIdx = slots - 1
@@ -30,7 +31,7 @@ export function dateCellSelection(start, rowBox, box, slots){
   let cellWidth = slotWidth(rowBox, slots);
 
   // cell under the mouse
-  let currentSlot = getCellAtX(rowBox, box.x, cellWidth);
+  let currentSlot = getCellAtX(rowBox, box.x, cellWidth, rtl, slots);
 
   // Identify row as either the initial row
   // or the row under the current mouse point
@@ -61,7 +62,8 @@ export function dateCellSelection(start, rowBox, box, slots){
 
   if (isStartRow) {
     // select the cell under the initial point
-    startIdx = endIdx = Math.floor((start.x - rowBox.left) / cellWidth)
+    startIdx = endIdx = ( rtl ? lastSlotIdx - Math.floor((start.x - rowBox.left) / cellWidth) :
+                                Math.floor((start.x - rowBox.left) / cellWidth));
 
     if (isCurrentRow) {
       if (currentSlot < startIdx) startIdx = currentSlot


### PR DESCRIPTION
When trying to select a range of days ( when in Months view ) and using a RTL language (such as Hebrew) you'll find it buggy. It'll select the opposite days when in the current row and will do some weird stuff when passing between rows. I could not find any open issues or pull requests regarding that matter, so I decided to do it myself. I also added some documentation to the code to help me better understand it while finding a solution (I can take it down if it's a problem).

TL;DR
- The problem: Wrong selection indexes when using RTL language.
- Ways to reproduce the bug: Use the i18n example. Edit cultures.js by adding the **selectable** prop. Run it and select ar-AE.

p.s
This is my first time creating a pull request.
