### PR TITLE
Bugfix: Multiple showmore popups are being rendered

### DIFF
--- a/src/Month.jsx
+++ b/src/Month.jsx
@@ -121,7 +121,9 @@ let MonthView = React.createClass({
         { weeks.map((week, idx) =>
             this.renderWeek(week, idx, measure && this._renderMeasureRows))
         }
-        { this.props.popup && this.state.overlay?this._renderOverlay():null}
+        { this.props.popup &&
+            this._renderOverlay()
+        }
       </div>
     )
   },

--- a/src/Month.jsx
+++ b/src/Month.jsx
@@ -121,6 +121,7 @@ let MonthView = React.createClass({
         { weeks.map((week, idx) =>
             this.renderWeek(week, idx, measure && this._renderMeasureRows))
         }
+        { this.props.popup && this.state.overlay?this._renderOverlay():null}
       </div>
     )
   },
@@ -163,9 +164,6 @@ let MonthView = React.createClass({
               this.renderShowMore(segments, extra, week, weekIdx, levels.length)
           }
         </div>
-        { this.props.popup
-            && this._renderOverlay()
-        }
       </div>
     )
   },


### PR DESCRIPTION
Issue: One popup per row [per week] was being rendered

Solution: Moved _renderOverlay from renderWeek() to render(), also added check for this.state.overlay

This resolves the issue of popup closing on clicking inside the popup [or selecting any event]