### PR TITLE
add background events

### DIFF
--- a/examples/App.js
+++ b/examples/App.js
@@ -32,6 +32,7 @@ const Example = React.createClass({
       rendering: require('./demos/rendering'),
       customView: require('./demos/customView'),
       timeslots: require('./demos/timeslots'),
+      backgroundEvents: require('./demos/backgroundEvents')
     }[selected];
 
     return (
@@ -75,6 +76,9 @@ const Example = React.createClass({
               </li>
               <li className={cn({active: selected === 'rendering' })}>
                 <a href='#' onClick={this.select.bind(null, 'rendering')}>Custom rendering</a>
+              </li>
+              <li className={cn({active: selected === 'backgroundEvents' })}>
+                <a href='#' onClick={this.select.bind(null, 'backgroundEvents')}>Background events</a>
               </li>
               {/* temporary hide link to documentation
               <li className={cn({active: selected === 'customView' })}>

--- a/examples/backgroundEvents.js
+++ b/examples/backgroundEvents.js
@@ -1,0 +1,77 @@
+export default [
+  {
+    'title': 'All Day Event',
+    'allDay': true,
+    'start': new Date(2015, 3, 0),
+    'end': new Date(2015, 3, 0)
+  },
+  {
+    'title': 'Background',
+    'allDay': true,
+    'background': true,
+    'start': new Date(2015, 3, 1),
+    'end': new Date(2015, 3, 1)
+  },
+  {
+    'title': 'Long Event',
+    'start': new Date(2015, 3, 7),
+    'end': new Date(2015, 3, 10)
+  },
+
+  {
+    'title': 'DTS STARTS',
+    'start': new Date(2016, 2, 13, 0, 0, 0),
+    'end': new Date(2016, 2, 20, 0, 0, 0)
+  },
+
+  {
+    'title': 'DTS ENDS',
+    'start': new Date(2016, 10, 6, 0, 0, 0),
+    'end': new Date(2016, 10, 13, 0, 0, 0)
+  },
+
+  {
+    'title': 'Some Event',
+    'start': new Date(2015, 3, 9, 0, 0, 0),
+    'end': new Date(2015, 3, 9, 0, 0, 0)
+  },
+  {
+    'title': 'Conference',
+    'start': new Date(2015, 3, 11),
+    'end': new Date(2015, 3, 13),
+    desc: 'Big conference for important people'
+  },
+  {
+    'title': 'Meeting',
+    'start': new Date(2015, 3, 12, 10, 30, 0, 0),
+    'end': new Date(2015, 3, 12, 12, 30, 0, 0),
+    desc: 'Pre-meeting meeting, to prepare for the meeting'
+  },
+  {
+    'title': 'Lunch',
+    'start':new Date(2015, 3, 12, 12, 0, 0, 0),
+    'end': new Date(2015, 3, 12, 13, 0, 0, 0),
+    desc: 'Power lunch'
+  },
+  {
+    'title': 'Meeting',
+    'start':new Date(2015, 3, 12,14, 0, 0, 0),
+    'end': new Date(2015, 3, 12,15, 0, 0, 0)
+  },
+  {
+    'title': 'Happy Hour',
+    'start':new Date(2015, 3, 12, 17, 0, 0, 0),
+    'end': new Date(2015, 3, 12, 17, 30, 0, 0),
+    desc: 'Most important meal of the day'
+  },
+  {
+    'title': 'Dinner',
+    'start':new Date(2015, 3, 12, 20, 0, 0, 0),
+    'end': new Date(2015, 3, 12, 21, 0, 0, 0)
+  },
+  {
+    'title': 'Birthday Party',
+    'start':new Date(2015, 3, 13, 7, 0, 0),
+    'end': new Date(2015, 3, 13, 10, 30, 0)
+  }
+]

--- a/examples/demos/backgroundEvents.js
+++ b/examples/demos/backgroundEvents.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import BigCalendar from 'react-big-calendar';
+import events from '../backgroundEvents';
+
+function BackgroundEvent({ event }) {
+  return (
+    <span>
+      <strong>
+        {event.title}
+      </strong>
+    </span>
+  )
+}
+
+function backgroundEventPropGetter() {
+  return {
+    className: 'background-event',
+    style: {
+      'background': 'green'
+    }
+  }
+}
+let BackgroundEvents = React.createClass({
+  render(){
+    return (
+      <BigCalendar
+        {...this.props}
+        events={events}
+        components={{
+          backgroundEvent: BackgroundEvent
+        }}
+        backgroundEventPropGetter={backgroundEventPropGetter}
+        defaultDate={new Date(2015, 3, 1)}
+      />
+    )
+  }
+})
+
+export default BackgroundEvents;
+

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "style": "lib/css/react-big-calendar.css",
   "files": [
     "lib/",
+    "src/",
     "LICENSE",
     "README.md",
     "CHANGELOG.md"

--- a/src/BackgroundCells.jsx
+++ b/src/BackgroundCells.jsx
@@ -1,17 +1,23 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { findDOMNode } from 'react-dom';
 import cn from 'classnames';
+import { elementType } from './utils/propTypes';
 import { segStyle } from './utils/eventLevels';
 import { notify } from './utils/helpers';
+import dates from './utils/dates';
 import { dateCellSelection, slotWidth, getCellAtX, pointInBox } from './utils/selection';
 import Selection, { getBoundsForNode } from './Selection';
 
 class DisplayCells extends React.Component {
 
   static propTypes = {
-    selectable: React.PropTypes.bool,
-    onSelect: React.PropTypes.func,
-    slots: React.PropTypes.number
+    selectable: PropTypes.bool,
+    onSelect: PropTypes.func,
+    slots: PropTypes.number,
+    week: PropTypes.array,
+    backgroundEvents: PropTypes.array,
+    backgroundEventComponent: elementType,
+    backgroundEventPropGetter: PropTypes.func
   }
 
   state = { selecting: false }
@@ -33,20 +39,43 @@ class DisplayCells extends React.Component {
   }
 
   render(){
-    let { slots } = this.props;
+    let { slots, week, backgroundEvents, backgroundEventComponent,
+          backgroundEventPropGetter, ...props } = this.props;
     let { selecting, startIdx, endIdx } = this.state
 
     let children = [];
 
     for (var i = 0; i < slots; i++) {
+      let backgroundEvent = backgroundEvents.find(event => {
+        return dates.sameDay(event.start, week[i])
+      })
+
+      let Component = backgroundEventComponent;
+      let title = (backgroundEvent || {}).title;
+
+      var style, xClassName;
+      if (backgroundEvent && backgroundEventPropGetter)
+        ({ style, className: xClassName } = backgroundEventPropGetter(backgroundEvent));
+      else
+        ({ style, className: xClassName } = {});
+
       children.push(
         <div
           key={'bg_' + i}
-          style={segStyle(1, slots)}
-          className={cn('rbc-day-bg', {
+          style={{...segStyle(1, slots), ...style}}
+          className={cn('rbc-day-bg', xClassName, {
             'rbc-selected-cell': selecting && i >= startIdx && i <= endIdx
           })}
-        />
+        >
+        { Component && backgroundEvent
+          ? <Component
+              event={backgroundEvent}
+              eventPropGetter={backgroundEventPropGetter}
+            />
+          : title
+        }
+
+        </div>
       )
     }
 

--- a/src/BackgroundCells.jsx
+++ b/src/BackgroundCells.jsx
@@ -62,7 +62,7 @@ class DisplayCells extends React.Component {
       children.push(
         <div
           key={'bg_' + i}
-          style={{...segStyle(1, slots), ...style}}
+          style={{...segStyle(1, slots), ...style, ...props.style}}
           className={cn('rbc-day-bg', xClassName, {
             'rbc-selected-cell': selecting && i >= startIdx && i <= endIdx
           })}

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -182,7 +182,7 @@ let Calendar = React.createClass({
 
     /**
      * Optionally provide a function that returns an object of className or style props
-     * to be applied to the the event node.
+     * to be applied to the event node.
      *
      * ```js
      * function(
@@ -195,6 +195,20 @@ let Calendar = React.createClass({
      */
     eventPropGetter: PropTypes.func,
 
+    /**
+     * Optionally provide a function that returns an object of className or style props
+     * to be applied to the backgroundEvent node.
+     *
+     * ```js
+     * function(
+     * 	backgroundEvent: object,
+     * 	start: date,
+     * 	end: date
+     * ) -> { className: string?, style: object? }
+     * ```
+     */
+
+    backgroundEventPropGetter: PropTypes.func,
     /**
      * Accessor for the event title, used to display event information. Should
      * resolve to a `renderable` value.
@@ -329,6 +343,7 @@ let Calendar = React.createClass({
      * ```jsx
      * let components = {
      *   event: MyEvent, // used by each view (Month, Day, Week)
+     *   backgroundEvent: MyBackgroundEvent,
      *   toolbar: MyToolbar,
      *   agenda: {
      *   	 event: MyAgendaEvent // with the agenda view use a different component to render events
@@ -340,6 +355,8 @@ let Calendar = React.createClass({
     components: PropTypes.shape({
       event: elementType,
 
+      backgroundEvent: elementType,
+
       toolbar: elementType,
 
       agenda: PropTypes.shape({
@@ -350,14 +367,17 @@ let Calendar = React.createClass({
 
       day: PropTypes.shape({
         header: elementType,
+        backgroundEvent: elementType,
         event: elementType
       }),
       week: PropTypes.shape({
         header: elementType,
+        backgroundEvent: elementType,
         event: elementType
       }),
       month: PropTypes.shape({
         header: elementType,
+        backgroundEvent: elementType,
         event: elementType
       })
     }),

--- a/src/Month.jsx
+++ b/src/Month.jsx
@@ -54,6 +54,7 @@ let propTypes = {
 
   onSelectEvent: React.PropTypes.func,
   onSelectSlot: React.PropTypes.func
+
 };
 
 let MonthView = React.createClass({
@@ -131,7 +132,7 @@ let MonthView = React.createClass({
 
   renderWeek(week, weekIdx, content) {
     let { first, last } = endOfRange(week);
-    let evts = eventsForWeek(this.props.events, week[0], week[week.length - 1], this.props)
+    let evts = eventsForWeek(this.props.events.filter(e => !e.background), week[0], week[week.length - 1], this.props)
 
     evts.sort((a, b) => sortEvents(a, b, this.props))
 
@@ -174,6 +175,8 @@ let MonthView = React.createClass({
   renderBackground(row, idx){
     let self = this;
 
+    let evts = eventsForWeek(this.props.events.filter(e => e.background), row[0], row[row.length - 1], this.props)
+
     function onSelectSlot({ start, end }) {
       self._pendingSelection = self._pendingSelection
         .concat(row.slice(start, end + 1))
@@ -189,6 +192,10 @@ let MonthView = React.createClass({
       container={() => findDOMNode(this)}
       selectable={this.props.selectable}
       ref={r => this._bgRows[idx] = r}
+      week={row}
+      backgroundEventComponent={this.props.components.backgroundEvent}
+      backgroundEvents={evts}
+      backgroundEventPropGetter={this.props.backgroundEventPropGetter}
     />
     )
   },

--- a/src/TimeGrid.jsx
+++ b/src/TimeGrid.jsx
@@ -263,6 +263,8 @@ export default class TimeGrid extends Component {
               container={()=> this.refs.allDay}
               selectable={this.props.selectable}
               onSelectSlot={handleSelectSlot}
+              week={range}
+              backgroundEvents={[]}
             />
             <div style={{ zIndex: 1, position: 'relative' }}>
               {this.renderAllDayEvents(range, levels)}

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -97,6 +97,10 @@ let dates = Object.assign(dateMath, {
     return dates.eq(dateA, dateB, 'month')
   },
 
+  sameDay(dateA, dateB){
+    return dates.eq(dateA, dateB, 'day')
+  },
+
   isToday(date) {
     return dates.eq(date, dates.today(), 'day')
   },


### PR DESCRIPTION
Hi, I was interested in the suggestion by @dmoskovsov in #103 so I tried to resolve the concerns you had about the API there.  An event object has a Boolean flag to mark it as `background`; the default behavior is to place the title of a background event in the same row as the event date on the month calendar, but it's also possible to set up a separate component and prop getter to structure and style the background event. 