### PR TITLE
Included SyntheticEvent object in callback for onSelect in EventCell

### DIFF
--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -113,7 +113,7 @@ let Calendar = React.createClass({
      * Callback fired when a calendar event is selected.
      *
      * ```js
-     * function(event: object)
+     * function(event: object, e: SyntheticEvent)
      * ```
      */
     onSelectEvent: PropTypes.func,
@@ -507,8 +507,8 @@ let Calendar = React.createClass({
       this.props.onView(view)
   },
 
-  handleSelectEvent(event){
-    notify(this.props.onSelectEvent, event)
+  handleSelectEvent(...args){
+    notify(this.props.onSelectEvent, args)
   },
 
   handleSelectSlot(slotInfo){

--- a/src/DayColumn.jsx
+++ b/src/DayColumn.jsx
@@ -294,9 +294,9 @@ let DaySlot = React.createClass({
     })
   },
 
-  _select(event){
+  _select(...args){
     clearTimeout(this._clickTimer);
-    notify(this.props.onSelectEvent, event)
+    notify(this.props.onSelectEvent, args)
   }
 });
 

--- a/src/DayColumn.jsx
+++ b/src/DayColumn.jsx
@@ -159,7 +159,7 @@ let DaySlot = React.createClass({
           key={'evt_' + idx}
           style={{...xStyle, ...style}}
           title={label + ': ' + title }
-          onClick={this._select.bind(null, event)}
+          onClick={(e) => this._select(event, e)}
           className={cn('rbc-event', className, {
             'rbc-selected': _isSelected,
             'rbc-event-overlaps': lastLeftOffset !== 0

--- a/src/EventCell.jsx
+++ b/src/EventCell.jsx
@@ -31,7 +31,7 @@ let EventCell = React.createClass({
           'rbc-event-continues-prior': continuesPrior,
           'rbc-event-continues-after': continuesAfter
         })}
-        onClick={()=> onSelect(event)}
+        onClick={(e)=> onSelect(event, e)}
       >
         <div className='rbc-event-content' title={title}>
           { Component


### PR DESCRIPTION
I created #215 and figured I'd submit a preliminary PR to see what you guys thought. It doesn't seem to be a huge change and would provide some interesting capabilities to users if they wanted. Currently on some of the views the arguments I am getting are 

`[event, SyntheticEvent, null, SyntheticEvent]` instead of `[event, SyntheticEvent]`

If this is something you guys are interested in, I can dig a bit more and find the source of that. I also think it might be interesting to provide this same capability to `onSelectSlot`, but I think that would be a bit more difficult given the dragging and my current use case doesn't require it.

Thoughts?