### PR TITLE
Fix errors for Meteor

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "lodash": "^3.10.1",
     "react-overlays": "^0.6.0",
     "react-prop-types": "^0.2.1",
-    "uncontrollable": "^3.1.0",
+    "uncontrollable": "^4.0.3",
     "warning": "^2.0.0"
   }
 }

--- a/src/BackgroundCells.jsx
+++ b/src/BackgroundCells.jsx
@@ -11,19 +11,10 @@ import Selection, { getBoundsForNode } from './Selection';
 
 class BackgroundCells extends React.Component {
 
-  static propTypes = {
-    cellWrapperComponent: elementType,
-    selectable: React.PropTypes.bool,
-    onSelect: React.PropTypes.func,
-    slots: React.PropTypes.number,
-    rtl: React.PropTypes.bool,
-    type: React.PropTypes.string,
-    values: React.PropTypes.arrayOf(
-      React.PropTypes.instanceOf(Date)
-    ),
+  constructor() {
+    super();
+    this.state = { selecting: false }
   }
-
-  state = { selecting: false }
 
   componentDidMount(){
     this.props.selectable
@@ -145,6 +136,18 @@ class BackgroundCells extends React.Component {
         start: startIdx, end: endIdx
       })
   }
+}
+
+BackgroundCells.propTypes = {
+  cellWrapperComponent: elementType,
+  selectable: React.PropTypes.bool,
+  onSelect: React.PropTypes.func,
+  slots: React.PropTypes.number,
+  rtl: React.PropTypes.bool,
+  type: React.PropTypes.string,
+  values: React.PropTypes.arrayOf(
+      React.PropTypes.instanceOf(Date)
+  ),
 }
 
 export default BackgroundCells;

--- a/src/TimeColumn.jsx
+++ b/src/TimeColumn.jsx
@@ -6,24 +6,6 @@ import dates from './utils/dates';
 import TimeSlotGroup from './TimeSlotGroup'
 
 export default class TimeColumn extends Component {
-  static propTypes = {
-    step: PropTypes.number.isRequired,
-    timeslots: PropTypes.number.isRequired,
-    now: PropTypes.instanceOf(Date).isRequired,
-    min: PropTypes.instanceOf(Date).isRequired,
-    max: PropTypes.instanceOf(Date).isRequired,
-    showLabels: PropTypes.bool,
-    timeGutterFormat: PropTypes.string,
-    type: PropTypes.string.isRequired,
-    className: PropTypes.string
-  }
-  static defaultProps = {
-    step: 30,
-    timeslots: 2,
-    showLabels: false,
-    type: 'day',
-    className: ''
-  }
 
   renderTimeSliceGroup(key, isNow, date) {
     const { components, timeslots, showLabels, step, timeGutterFormat } = this.props;
@@ -76,4 +58,24 @@ export default class TimeColumn extends Component {
       </div>
     )
   }
+}
+
+TimeColumn. propTypes = {
+  step: PropTypes.number.isRequired,
+  timeslots: PropTypes.number.isRequired,
+  now: PropTypes.instanceOf(Date).isRequired,
+  min: PropTypes.instanceOf(Date).isRequired,
+  max: PropTypes.instanceOf(Date).isRequired,
+  showLabels: PropTypes.bool,
+  timeGutterFormat: PropTypes.string,
+  type: PropTypes.string.isRequired,
+  className: PropTypes.string
+}
+
+TimeColumn.defaultProps = {
+  step: 30,
+  timeslots: 2,
+  showLabels: false,
+  type: 'day',
+  className: ''
 }

--- a/src/TimeGrid.jsx
+++ b/src/TimeGrid.jsx
@@ -29,33 +29,6 @@ const MIN_ROWS = 2;
 
 export default class TimeGrid extends Component {
 
-  static propTypes = {
-    ...DayColumn.propTypes,
-    ...TimeColumn.propTypes,
-
-    step: React.PropTypes.number,
-    min: React.PropTypes.instanceOf(Date),
-    max: React.PropTypes.instanceOf(Date),
-    scrollToTime: React.PropTypes.instanceOf(Date),
-    dayFormat: dateFormat,
-    rtl: React.PropTypes.bool
-  }
-
-  static defaultProps = {
-    ...DayColumn.defaultProps,
-    ...TimeColumn.defaultProps,
-
-    step: 30,
-    min: dates.startOf(new Date(), 'day'),
-    max: dates.endOf(new Date(), 'day'),
-    scrollToTime: dates.startOf(new Date(), 'day'),
-    /* these 2 are needed to satisfy requirements from TimeColumn required props
-     * There is a strange bug in React, using ...TimeColumn.defaultProps causes weird crashes
-     */
-    type: 'gutter',
-    now: new Date()
-  }
-
   constructor(props) {
     super(props)
     this.state = { gutterWidth: undefined, isOverflowing: null };
@@ -387,3 +360,31 @@ export default class TimeGrid extends Component {
   }
 
 }
+
+TimeGrid.propTypes = {
+  ...DayColumn.propTypes,
+  ...TimeColumn.propTypes,
+
+  step: React.PropTypes.number,
+  min: React.PropTypes.instanceOf(Date),
+  max: React.PropTypes.instanceOf(Date),
+  scrollToTime: React.PropTypes.instanceOf(Date),
+  dayFormat: dateFormat,
+  rtl: React.PropTypes.bool
+};
+
+TimeGrid.defaultProps = {
+  ...DayColumn.defaultProps,
+  ...TimeColumn.defaultProps,
+
+  step: 30,
+  min: dates.startOf(new Date(), 'day'),
+  max: dates.endOf(new Date(), 'day'),
+  scrollToTime: dates.startOf(new Date(), 'day'),
+  /* these 2 are needed to satisfy requirements from TimeColumn required props
+   * There is a strange bug in React, using ...TimeColumn.defaultProps causes weird crashes
+   */
+  type: 'gutter',
+  now: new Date()
+};
+

--- a/src/TimeSlot.jsx
+++ b/src/TimeSlot.jsx
@@ -4,21 +4,6 @@ import { elementType } from './utils/propTypes'
 
 
 export default class TimeSlot extends Component {
-  static propTypes = {
-    dayWrapperComponent: elementType,
-    value: PropTypes.instanceOf(Date).isRequired,
-    isNow: PropTypes.bool,
-    showLabel: PropTypes.bool,
-    content: PropTypes.string,
-    culture: PropTypes.string
-  }
-
-  static defaultProps = {
-    isNow: false,
-    showLabel: false,
-    content: ''
-  }
-
   render() {
     const { value } = this.props;
     const Wrapper = this.props.dayWrapperComponent;
@@ -40,3 +25,19 @@ export default class TimeSlot extends Component {
     )
   }
 }
+
+TimeSlot.propTypes = {
+  dayWrapperComponent: elementType,
+  value: PropTypes.instanceOf(Date).isRequired,
+  isNow: PropTypes.bool,
+  showLabel: PropTypes.bool,
+  content: PropTypes.string,
+  culture: PropTypes.string
+};
+
+TimeSlot.defaultProps = {
+  isNow: false,
+  showLabel: false,
+  content: ''
+};
+

--- a/src/TimeSlotGroup.jsx
+++ b/src/TimeSlotGroup.jsx
@@ -5,23 +5,6 @@ import localizer from './localizer'
 import { elementType } from './utils/propTypes'
 
 export default class TimeSlotGroup extends Component {
-  static propTypes = {
-    dayWrapperComponent: elementType,
-    timeslots: PropTypes.number.isRequired,
-    step: PropTypes.number.isRequired,
-    value: PropTypes.instanceOf(Date).isRequired,
-    showLabels: PropTypes.bool,
-    isNow: PropTypes.bool,
-    timeGutterFormat: PropTypes.string,
-    culture: PropTypes.string
-  }
-  static defaultProps = {
-    timeslots: 2,
-    step: 30,
-    isNow: false,
-    showLabels: false
-  }
-
   renderSlice(slotNumber, content, value) {
     const { dayWrapperComponent, showLabels, isNow, culture } = this.props;
     return (
@@ -56,3 +39,22 @@ export default class TimeSlotGroup extends Component {
     )
   }
 }
+
+TimeSlotGroup.propTypes = {
+  dayWrapperComponent: elementType,
+  timeslots: PropTypes.number.isRequired,
+  step: PropTypes.number.isRequired,
+  value: PropTypes.instanceOf(Date).isRequired,
+  showLabels: PropTypes.bool,
+  isNow: PropTypes.bool,
+  timeGutterFormat: PropTypes.string,
+  culture: PropTypes.string
+};
+
+TimeSlotGroup.defaultProps = {
+  timeslots: 2,
+  step: 30,
+  isNow: false,
+  showLabels: false
+};
+

--- a/src/addons/dragAndDrop/index.js
+++ b/src/addons/dragAndDrop/index.js
@@ -29,21 +29,18 @@ export default function withDragAndDrop(Calendar, {
     componentWillMount() {
       let monitor = this.context.dragDropManager.getMonitor()
       this.monitor = monitor
-      this.unsubscribeToStateChange = monitor
-        .subscribeToStateChange(this.handleStateChange)
+      this.unsubscribeToStateChange = monitor.subscribeToStateChange(() => {
+        const isDragging = !!this.monitor.getItem();
+
+        if (isDragging !== this.state.isDragging) {
+          setTimeout(() => this.setState({ isDragging }));
+        }
+      })
     }
 
     componentWillUnmount() {
       this.monitor = null
       this.unsubscribeToStateChange()
-    }
-
-    handleStateChange = () => {
-      const isDragging = !!this.monitor.getItem();
-
-      if (isDragging !== this.state.isDragging) {
-        setTimeout(() => this.setState({ isDragging }));
-      }
     }
 
     render() {


### PR DESCRIPTION
When being used for Meteor projects,
1. defining propTypes inside class extensions causes errors. Thus moving propTypes and defaultPropTypes outside of class def.
2. Move state variable creation into constructors.
3. Upgrade uncontrollable to 4.0.3, which fixes compatibility error with React >= 15: https://github.com/jquense/uncontrollable/commit/47b1645142cb83c29032cbc4c30dd2eb56c5d292 