### PR TITLE
Make button toolbar more responsive

### DIFF
--- a/examples/styles.less
+++ b/examples/styles.less
@@ -38,21 +38,11 @@ h4 {
 
 .examples {
   position: relative;
-  height: 100vh;
-  display: flex;
-  flex-direction: column;
 }
 
 .example {
   font-size: 14px;
   flex: 1;
-
-  &,
-  & > * {
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
-  }
 
   .demo,
   .rbc-calendar {
@@ -79,9 +69,8 @@ h4 > a > code  {
 
 .view-source {
   font-size: 90%;
-  float: right;
   margin-bottom: 15px;
-  margin-left: auto;
+  text-align: right;
 }
 
 .callout {

--- a/src/less/toolbar.less
+++ b/src/less/toolbar.less
@@ -8,9 +8,9 @@
   align-items: center;
   margin-bottom: 10px;
   font-size: 16px;
+  justify-content: space-between;
 
   .rbc-toolbar-label {
-    width: 100%;
     padding: 0 10px;
     text-align: center;
   }
@@ -59,8 +59,13 @@
 }
 
 .rbc-btn-group {
-  display: inline-block;
-  white-space: nowrap;
+  display: flex;
+  width: 38%;
+  flex-wrap: wrap;
+
+  &:last-child {
+    justify-content: flex-end;
+  }
 
   > button:first-child:not(:last-child) {
     border-top-right-radius: 0;


### PR DESCRIPTION
The button toolbar wasn't scaling down nicely to smaller devices. This allows the buttons the overflow and keeps the calendar month/label centered.

Also had to modify the demo styles so calendar didn't display beyond its container.