### PR TITLE
BackgroundCells PropTypes - allow `selectable` to take 'ignoreEvents'

### DIFF
--- a/src/BackgroundCells.jsx
+++ b/src/BackgroundCells.jsx
@@ -13,7 +13,7 @@ class BackgroundCells extends React.Component {
 
   static propTypes = {
     cellWrapperComponent: elementType,
-    selectable: React.PropTypes.bool,
+    selectable: React.PropTypes.oneOf([true, false, 'ignoreEvents']),
     onSelect: React.PropTypes.func,
     slots: React.PropTypes.number,
     rtl: React.PropTypes.bool,


### PR DESCRIPTION
Fixes #244 