### PR TITLE
Remove invalid less selector for less4j

### DIFF
--- a/src/less/time-grid.less
+++ b/src/less/time-grid.less
@@ -33,7 +33,7 @@
     z-index: 4;
   }
 
-  .rbc-row > {
+  .rbc-row {
     min-height: 20px;
   }
 }


### PR DESCRIPTION
time-grid.less has a dangling child selector (`.rbc-row > {`) which is technically illegal less syntax. The normal js-based less compiler everyone uses will ignore the child selector and emit css anyway, but alternative less compilers (like the java-based less4j) have stricter syntax requirements and error-out when they encounter this construct.

Patch removes the dangling child selector.