### PR TITLE
Fix dnd date merge when moving an event to a date cell

### DIFF
--- a/src/addons/dragAndDrop/backgroundWrapper.js
+++ b/src/addons/dragAndDrop/backgroundWrapper.js
@@ -11,7 +11,7 @@ export function getEventTimes({ start, end }, dropDate, type) {
 
   // If the event is dropped in a "Day" cell, preserve an event's start time by extracting the hours and minutes off
   // the original start date and add it to newDate.value
-  const nextStart = type === 'dateWrapper'
+  const nextStart = type === 'dateCellWrapper'
     ? dates.merge(dropDate, start) : dropDate
 
   const nextEnd = dates.add(nextStart, duration, 'milliseconds')


### PR DESCRIPTION
Before (you can see the bug here http://intljusticemission.github.io/react-big-calendar/examples/index.html#api ):

- if you move the 7am event to a different date cell, the time will be reset to 0am

After:

- when moving events to a date cell wrapper, time will be preserved (date will be changed, but time will still be 7am)

This PR fully fixes it.