### PR TITLE
Pass mouse event action to onSelectSlot() callback

### DIFF
--- a/src/BackgroundCells.js
+++ b/src/BackgroundCells.js
@@ -138,10 +138,7 @@ class BackgroundCells extends React.Component {
 
     selector
       .on('select', () => {
-        this._selectSlot(Object.assign({},
-          this.state, {
-            action: 'select'
-          }))
+        this._selectSlot({ ...this.state, action: 'select' })
         this._initial = {}
         this.setState({ selecting: false })
         notify(this.props.onSelectEnd, [this.state]);

--- a/src/BackgroundCells.js
+++ b/src/BackgroundCells.js
@@ -126,7 +126,8 @@ class BackgroundCells extends React.Component {
 
             this._selectSlot({
               startIdx: currentCell,
-              endIdx: currentCell
+              endIdx: currentCell,
+              action: 'click',
             })
           }
         }
@@ -137,7 +138,10 @@ class BackgroundCells extends React.Component {
 
     selector
       .on('select', () => {
-        this._selectSlot(this.state)
+        this._selectSlot(Object.assign({},
+          this.state, {
+            action: 'select'
+          }))
         this._initial = {}
         this.setState({ selecting: false })
         notify(this.props.onSelectEnd, [this.state]);
@@ -150,11 +154,13 @@ class BackgroundCells extends React.Component {
     this._selector = null;
   }
 
-  _selectSlot({ endIdx, startIdx }) {
+  _selectSlot({ endIdx, startIdx, action }) {
     if (endIdx !== -1 && startIdx !== -1)
       this.props.onSelectSlot &&
         this.props.onSelectSlot({
-          start: startIdx, end: endIdx
+          start: startIdx,
+          end: endIdx,
+          action
         })
   }
 }

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -103,7 +103,7 @@ let Calendar = React.createClass({
      *     start: Date,
      *     end: Date,
      *     slots: array<Date>,
-     *     action: string
+     *     action: "select" | "click"
      *   }
      * )
      * ```

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -102,7 +102,8 @@ let Calendar = React.createClass({
      *   slotInfo: object {
      *     start: Date,
      *     end: Date,
-     *     slots: array<Date>
+     *     slots: array<Date>,
+     *     action: string
      *   }
      * )
      * ```

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -271,11 +271,7 @@ let DaySlot = React.createClass({
     selector
       .on('click', (box) => {
         if (!isEvent(findDOMNode(this), box))
-          this._selectSlot(Object.assign({},
-            selectionState(box), {
-              action: 'click'
-            }
-          ))
+          this._selectSlot({ ...selectionState(box), action: 'click' })
 
         this.setState({ selecting: false })
       })
@@ -283,11 +279,7 @@ let DaySlot = React.createClass({
     selector
       .on('select', () => {
         if (this.state.selecting) {
-          this._selectSlot(Object.assign({},
-            this.state, {
-              action: 'select'
-            }
-          ))
+          this._selectSlot({ ...this.state, action: 'select' })
           this.setState({ selecting: false })
         }
       })

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -271,7 +271,11 @@ let DaySlot = React.createClass({
     selector
       .on('click', (box) => {
         if (!isEvent(findDOMNode(this), box))
-          this._selectSlot(selectionState(box))
+          this._selectSlot(Object.assign({},
+            selectionState(box), {
+              action: 'click'
+            }
+          ))
 
         this.setState({ selecting: false })
       })
@@ -279,7 +283,11 @@ let DaySlot = React.createClass({
     selector
       .on('select', () => {
         if (this.state.selecting) {
-          this._selectSlot(this.state)
+          this._selectSlot(Object.assign({},
+            this.state, {
+              action: 'select'
+            }
+          ))
           this.setState({ selecting: false })
         }
       })
@@ -291,7 +299,7 @@ let DaySlot = React.createClass({
     this._selector = null;
   },
 
-  _selectSlot({ startDate, endDate }) {
+  _selectSlot({ startDate, endDate, action }) {
     let current = startDate
       , slots = [];
 
@@ -303,7 +311,8 @@ let DaySlot = React.createClass({
     notify(this.props.onSelectSlot, {
       slots,
       start: startDate,
-      end: endDate
+      end: endDate,
+      action
     })
   },
 

--- a/src/Month.js
+++ b/src/Month.js
@@ -289,12 +289,12 @@ let MonthView = React.createClass({
     })
   },
 
-  handleSelectSlot(range) {
+  handleSelectSlot(range, slotInfo) {
     this._pendingSelection = this._pendingSelection
       .concat(range)
 
     clearTimeout(this._selectTimer)
-    this._selectTimer = setTimeout(()=> this._selectDates())
+    this._selectTimer = setTimeout(()=> this._selectDates(slotInfo))
   },
 
   handleHeadingClick(date, view, e){
@@ -308,7 +308,7 @@ let MonthView = React.createClass({
     notify(this.props.onSelectEvent, args)
   },
 
-  _selectDates() {
+  _selectDates(slotInfo) {
     let slots = this._pendingSelection.slice()
 
     this._pendingSelection = []
@@ -318,7 +318,8 @@ let MonthView = React.createClass({
     notify(this.props.onSelectSlot, {
       slots,
       start: slots[0],
-      end: slots[slots.length - 1]
+      end: slots[slots.length - 1],
+      action: slotInfo.action
     })
   },
 

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -122,12 +122,13 @@ export default class TimeGrid extends Component {
     }
   }
 
-  handleSelectAllDaySlot = (slots) => {
+  handleSelectAllDaySlot = (slots, slotInfo) => {
     const { onSelectSlot } = this.props;
     notify(onSelectSlot, {
       slots,
       start: slots[0],
-      end: slots[slots.length - 1]
+      end: slots[slots.length - 1],
+      action: slotInfo.action
     })
   }
 


### PR DESCRIPTION
An `action` of `'click'` or `'select'` is now included in the object passed to the `onSelectSlot` callback.

Addresses #323 -- I tried to touch as little code as possible