### PR TITLE
Make previous message more obvious to translate

### DIFF
--- a/src/utils/messages.js
+++ b/src/utils/messages.js
@@ -8,7 +8,7 @@ import invariant from 'invariant';
   week: 'week',
   day: 'day',
   month: 'month',
-  previous: 'back',
+  previous: 'previous',
   next: 'next',
   yesterday: 'yesterday',
   tomorrow: 'tomorrow',


### PR DESCRIPTION
Why previous message is the only message with a different default translation? It can be easier to translate messages if default translation is 'previous', isn't it?