### PR TITLE
More Functionality from eventPropGetter

### DIFF
--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -162,7 +162,7 @@ let DaySlot = React.createClass({
       if (eventPropGetter)
         var { style: xStyle, className } = eventPropGetter(event, start, end, _isSelected)
 
-      let { height, top, width, xOffset } = style
+      let { height, top, width, xOffset} = Object.assign({}, style, xStyle)
 
       return (
         <EventWrapper event={event} key={'evt_' + idx}>


### PR DESCRIPTION
Add support for custom positioning returned from eventPropGetter.

It's come up in my own work with this library that I wanted to be able to change the way that events are positioned. It doesn't work for my application to have them overlap as they currently do. This is a bit of a hacky fix...I'm sure there's probably a better way to do it, but I wanted to propose the change and open up discussion about it. 