### PR TITLE
Use withDragAndDrop addon without DnDContext

### DIFF
--- a/src/addons/dragAndDrop/index.js
+++ b/src/addons/dragAndDrop/index.js
@@ -14,7 +14,8 @@ try {
 
 
 export default function withDragAndDrop(Calendar, {
-  backend = html5Backend
+  backend = html5Backend,
+  withDnDContext = true
 } = {}) {
 
   class DragAndDropCalendar extends React.Component {
@@ -101,5 +102,9 @@ export default function withDragAndDrop(Calendar, {
     endAccessor: accessor
   }
 
-  return DragDropContext(backend)(DragAndDropCalendar);
+  if (withDnDContext) {
+    return DragDropContext(backend)(DragAndDropCalendar);
+  } else {
+    return DragAndDropCalendar;
+  }
 }

--- a/src/addons/dragAndDrop/index.js
+++ b/src/addons/dragAndDrop/index.js
@@ -14,8 +14,7 @@ try {
 
 
 export default function withDragAndDrop(Calendar, {
-  backend = html5Backend,
-  withDnDContext = true
+  backend = html5Backend
 } = {}) {
 
   class DragAndDropCalendar extends React.Component {
@@ -102,9 +101,9 @@ export default function withDragAndDrop(Calendar, {
     endAccessor: accessor
   }
 
-  if (withDnDContext) {
-    return DragDropContext(backend)(DragAndDropCalendar);
-  } else {
+  if (backend === false) {
     return DragAndDropCalendar;
+  } else {
+    return DragDropContext(backend)(DragAndDropCalendar);
   }
 }


### PR DESCRIPTION
Hello everybody,

this pull request is for this issue https://github.com/intljusticemission/react-big-calendar/issues/350 , where once you have multiple HTML5Backend or Touch backends in your app, you can't use your app properly as you can't have 2 or more HTML5Backends at once.
This restriction about HTML5backend is documented, but it is not solved very well yet (https://github.com/react-dnd/react-dnd/issues/186). 

This pull request solves it by providing an option to choose if you want to use RBC with DragAndDrop context or you will provide your context in higher order component => you can use it like this: 
`const DragAndDropCalendar = withDragAndDrop(BigCalendar, { withDnDContext: false });`. 

This request does not contain any breaking changes.

I hope this will be useful for anyone else and not just me 😄 . 

Thank you and please merge this request 😄 .
