### PR TITLE
Add a class with the weekday

### DIFF
--- a/src/BackgroundCells.js
+++ b/src/BackgroundCells.js
@@ -68,6 +68,7 @@ class BackgroundCells extends React.Component {
                   'rbc-day-bg',
                   selected && 'rbc-selected-cell',
                   dates.isToday(date) && 'rbc-today',
+                  `rbc-weekday-${dates.weekday(date)}`,
                 )}
               />
             </Wrapper>

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -109,7 +109,8 @@ let DaySlot = React.createClass({
         {...props}
         className={cn(
           'rbc-day-slot',
-          dates.isToday(max) && 'rbc-today'
+          dates.isToday(max) && 'rbc-today',
+          `rbc-weekday-${dates.weekday(props.date)}`,
         )}
         now={now}
         min={min}

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -303,6 +303,7 @@ export default class TimeGrid extends Component {
           className={cn(
             'rbc-header',
             dates.isToday(date) && 'rbc-today',
+            `rbc-weekday-${dates.weekday(date)}`,
           )}
           style={segStyle(1, this.slots)}
         >


### PR DESCRIPTION
This change adds a class with the weekday, similar to the
`rbc-today`. The purpose of this class is to allow us to customize the
cells by day of the week. For instance, to customize weekends we could
do:

```
.rbc-weekday-0,
.rbc-weekday-6 {
  background: red;
}
```

I did not write any default styles to avoid breaking the API or the
default behavior and appearance. Hopefully, this will make it easier to
merge this change.

Please let me know what else I need to do to add this functionality.