### PR TITLE
Add an optional property for initially selected event

### DIFF
--- a/examples/demos/basic.js
+++ b/examples/demos/basic.js
@@ -8,6 +8,7 @@ let Basic = React.createClass({
       <BigCalendar
         {...this.props}
         events={events}
+        initialSelection={events[1]}
         defaultDate={new Date(2015, 3, 1)}
       />
     )

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -81,6 +81,11 @@ let Calendar = React.createClass({
     events: PropTypes.arrayOf(PropTypes.object),
 
     /**
+     * The element of events which is selected when the component mounts
+     */
+    initialSelection: PropTypes.object,
+
+    /**
      * Callback fired when the `date` value changes.
      *
      * @controllable date
@@ -581,6 +586,12 @@ let Calendar = React.createClass({
       this.handleViewChange(view)
 
     this.handleNavigate(navigate.DATE, date)
+  },
+  
+  componentDidMount () {
+    if (this.props.initialSelection) {
+      this.handleSelectEvent(this.props.initialSelection)
+    }
   }
 });
 


### PR DESCRIPTION
I am using big calendar on a view which the user jumps to by clicking on an url in an email. When the calendar is displayed I want the event referenced in the url to be selected. 

My proposed solution: add an optional property `initialSelection` to `Calendar`. The property contains one element of `events`. If the property is set, `handleSelectEvent` is called after the component has mounted with this element as argument.