### PR TITLE
Updated react-overlays to ^0.7.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "invariant": "^2.1.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.5.8",
-    "react-overlays": "^0.6.0",
+    "react-overlays": "^0.7.0",
     "react-prop-types": "^0.4.0",
     "uncontrollable": "^3.3.1 || ^4.0.0",
     "warning": "^2.0.0"


### PR DESCRIPTION
React v15.5 deprecates using `React.PropTypes` and instead you must import from `prop-types`. Also, `React.createClass` is deprecated and will be removed in version 16. 

This library has a dependency on react-overlays, which only fixes these issues in `0.7.0`. This PR allows for this new update to avoid these warnings/errors when using React Big Calendar. 