### PR TITLE
fix(package.json): fix peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "release": "release"
   },
   "peerDependencies": {
-    "react": "^0.14.9 || ^15.3.0",
-    "react-dom": "^0.14.9 || ^15.3.0"
+    "react": "^0.14.8 || ^15.3.0",
+    "react-dom": "^0.14.8 || ^15.3.0"
   },
   "devDependencies": {
     "@kadira/storybook": "^1.28.1",


### PR DESCRIPTION
It had react `0.14.9`, which doesn't exist as far as I can tell.  The last release before `15.0.0` was `0.14.8`.

Is there any reason that it's not `|| ^15.0.0` instead of `|| ^15.3.0`?