### PR TITLE
#384 Resolve PropTypes Warning on Event Click

### DIFF
--- a/src/EventRowMixin.js
+++ b/src/EventRowMixin.js
@@ -14,7 +14,7 @@ export default {
     end: PropTypes.instanceOf(Date),
     start: PropTypes.instanceOf(Date),
 
-    selected: PropTypes.array,
+    selected: PropTypes.object,
     eventPropGetter: PropTypes.func,
     titleAccessor: accessor,
     allDayAccessor: accessor,
@@ -28,7 +28,7 @@ export default {
 
   defaultProps: {
     segments: [],
-    selected: [],
+    selected: {},
     slots: 7
   },
 


### PR DESCRIPTION
#### Resolves
- #384 - Warning on Event Click

#### Notes
- Updated PropTypes declaration of selected in EventRowMixin as well as the default propType of selected to be an object