### PR TITLE
docs(Calendar): document `selected` (and `defaultSelected`) props

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -116,6 +116,8 @@ class Calendar extends React.Component {
     * ```js
     * function(event: object, e: SyntheticEvent)
     * ```
+    *
+    * @controllable selected
     */
    onSelectEvent: PropTypes.func,
 
@@ -129,6 +131,11 @@ class Calendar extends React.Component {
     * ```
     */
    onSelecting: PropTypes.func,
+     
+   /**
+    * The selected event, if any.
+    */
+   selected: PropTypes.object,
 
    /**
     * An array of built-in view names to allow the calendar to display.


### PR DESCRIPTION
fix #385