### PR TITLE
Use same convention as the example app

### DIFF
--- a/examples/Intro.md
+++ b/examples/Intro.md
@@ -27,8 +27,8 @@ const MyCalendar = props => (
   <div>
     <BigCalendar
       events={myEventsList}
-      startAccessor='startDate'
-      endAccessor='endDate'
+      startAccessor='start'
+      endAccessor='end'
     />
   </div>
 );


### PR DESCRIPTION
Ran into the same issue as this person: #162

I think it would be clearer if the example used the same accessors as the intro page.