### PR TITLE
Calculate segment padding according to actually visible dates

### DIFF
--- a/src/DateContentRow.js
+++ b/src/DateContentRow.js
@@ -161,7 +161,7 @@ class DateContentRow extends React.Component {
     let segments = this.segments = events.map(evt => eventSegments(evt, first, last, {
       startAccessor,
       endAccessor
-    }))
+    }, range))
 
     let { levels, extra } = eventLevels(segments, Math.max(maxRows - 1, 1));
     while (levels.length < minRows ) levels.push([])

--- a/src/utils/eventLevels.js
+++ b/src/utils/eventLevels.js
@@ -13,7 +13,7 @@ export function eventSegments(event, first, last, { startAccessor, endAccessor }
   let start = dates.max(dates.startOf(get(event, startAccessor), 'day'), first);
   let end = dates.min(dates.ceil(get(event, endAccessor), 'day'), last)
 
-  let padding = range.findIndex(x => x.getTime() === start.getTime());
+  let padding = range.findIndex(x => dates.eq(x, start, 'day'));
   let span = dates.diff(start, end, 'day');
 
   span = Math.min(span, slots)

--- a/src/utils/eventLevels.js
+++ b/src/utils/eventLevels.js
@@ -8,12 +8,12 @@ export function endOfRange(dateRange, unit = 'day') {
   }
 }
 
-export function eventSegments(event, first, last, { startAccessor, endAccessor }) {
+export function eventSegments(event, first, last, { startAccessor, endAccessor }, range) {
   let slots = dates.diff(first, last, 'day')
   let start = dates.max(dates.startOf(get(event, startAccessor), 'day'), first);
   let end = dates.min(dates.ceil(get(event, endAccessor), 'day'), last)
 
-  let padding = dates.diff(first, start, 'day');
+  let padding = range.findIndex(x => x.getTime() === start.getTime());
   let span = dates.diff(start, end, 'day');
 
   span = Math.min(span, slots)


### PR DESCRIPTION
I'm trying to make month view that has a filtered range (imagine defining visibleWeekDays=[1, 2, 3, 4, 5] to render all days except saturdays/sundays, or to have a shouldDayRender function that returns true/false depending on the date). These filters apply to the range that is handed to `<DateContentRow />`. 

Unfortunately, this doesn't currently work since the event padding is calculated via the difference between range start and event start. With this PR, we would get the correct padding without assuming that all dates are shown.

This is how a use-case this PR allows could look like:
![ohne titel](https://cloud.githubusercontent.com/assets/4349324/26303398/d93345d0-3ee7-11e7-82a1-3640920c5bed.jpeg)

Its simply a custom month-view rendered 4 times, that squeezes all days in one row and filters out saturdays/sundays. 
