### PR TITLE
export calenar class

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -52,7 +52,7 @@ let now = new Date();
  * on `Apr 8th 12:01:00 am` will. If you want _inclusive_ ranges consider providing a
  * function `endAccessor` that returns the end date + 1 day for those events that end at midnight.
  */
-class Calendar extends React.Component {
+export class Calendar extends React.Component {
  static propTypes = {
 
    /**
@@ -131,7 +131,7 @@ class Calendar extends React.Component {
     * ```
     */
    onSelecting: PropTypes.func,
-     
+
    /**
     * The selected event, if any.
     */


### PR DESCRIPTION
I wonder whether it's okay to export the Calendar class itself, in addition to exporting the component returned from uncontrollable. This would allow me to provide a custom render function by extending Calendar. 