### PR TITLE
Add support for "selectable" calendar on mobile

### DIFF
--- a/src/BackgroundCells.js
+++ b/src/BackgroundCells.js
@@ -16,6 +16,7 @@ class BackgroundCells extends React.Component {
     cellWrapperComponent: elementType,
     container: PropTypes.func,
     selectable: PropTypes.oneOf([true, false, 'ignoreEvents']),
+    longPressThreshold: PropTypes.number,
 
     onSelectSlot: PropTypes.func.isRequired,
     onSelectEnd: PropTypes.func,
@@ -84,7 +85,9 @@ class BackgroundCells extends React.Component {
 
   _selectable(){
     let node = findDOMNode(this);
-    let selector = this._selector = new Selection(this.props.container)
+    let selector = this._selector = new Selection(this.props.container, {
+      longPressThreshold: this.props.longPressThreshold,
+    })
 
     selector.on('selecting', box => {
       let { range, rtl } = this.props;

--- a/src/BackgroundCells.js
+++ b/src/BackgroundCells.js
@@ -113,7 +113,7 @@ class BackgroundCells extends React.Component {
       })
     })
 
-    selector.on('mousedown', (box) => {
+    selector.on('beforeSelect', (box) => {
       if (this.props.selectable !== 'ignoreEvents') return
 
       return !isEvent(findDOMNode(this), box)

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -211,6 +211,16 @@ class Calendar extends React.Component {
    selectable: PropTypes.oneOf([true, false, 'ignoreEvents']),
 
    /**
+    * Specifies the number of miliseconds the user must press and hold on the screen for a touch
+    * to be considered a "long press." Long presses are used for time slot selection on touch
+    * devices.
+    *
+    * @type {number}
+    * @default 250
+    */
+   longPressThreshold: PropTypes.number,
+
+   /**
     * Determines the selectable time increments in week and day views
     */
    step: PropTypes.number,
@@ -486,7 +496,9 @@ class Calendar extends React.Component {
    titleAccessor: 'title',
    allDayAccessor: 'allDay',
    startAccessor: 'start',
-   endAccessor: 'end'
+   endAccessor: 'end',
+
+   longPressThreshold: 250,
  };
 
  getViews = () => {

--- a/src/DateContentRow.js
+++ b/src/DateContentRow.js
@@ -25,6 +25,7 @@ const propTypes = {
   container: PropTypes.func,
   selected: PropTypes.object,
   selectable: PropTypes.oneOf([true, false, 'ignoreEvents']),
+  longPressThreshold: PropTypes.number,
 
   onShowMore: PropTypes.func,
   onSelectSlot: PropTypes.func,
@@ -150,6 +151,7 @@ class DateContentRow extends React.Component {
       eventWrapperComponent,
       onSelectStart,
       onSelectEnd,
+      longPressThreshold,
       ...props
     } = this.props;
 
@@ -177,6 +179,7 @@ class DateContentRow extends React.Component {
           onSelectEnd={onSelectEnd}
           onSelectSlot={this.handleSelectSlot}
           cellWrapperComponent={dateCellWrapper}
+          longPressThreshold={longPressThreshold}
         />
 
         <div className='rbc-row-content'>

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -257,7 +257,7 @@ class DaySlot extends React.Component {
     selector.on('selecting', maybeSelect)
     selector.on('selectStart', maybeSelect)
 
-    selector.on('mousedown', (box) => {
+    selector.on('beforeSelect', (box) => {
       if (this.props.selectable !== 'ignoreEvents') return
 
       return !isEvent(findDOMNode(this), box)

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -46,6 +46,7 @@ class DaySlot extends React.Component {
     selected: PropTypes.object,
     selectable: PropTypes.oneOf([true, false, 'ignoreEvents']),
     eventOffset: PropTypes.number,
+    longPressThreshold: PropTypes.number,
 
     onSelecting: PropTypes.func,
     onSelectSlot: PropTypes.func.isRequired,
@@ -202,7 +203,9 @@ class DaySlot extends React.Component {
 
   _selectable = () => {
     let node = findDOMNode(this);
-    let selector = this._selector = new Selection(()=> findDOMNode(this))
+    let selector = this._selector = new Selection(()=> findDOMNode(this), {
+      longPressThreshold: this.props.longPressThreshold,
+    })
 
     let maybeSelect = (box) => {
       let onSelecting = this.props.onSelecting

--- a/src/Month.js
+++ b/src/Month.js
@@ -50,6 +50,7 @@ let propTypes = {
 
   selected: PropTypes.object,
   selectable: PropTypes.oneOf([true, false, 'ignoreEvents']),
+  longPressThreshold: PropTypes.number,
 
   onNavigate: PropTypes.func,
   onSelectSlot: PropTypes.func,
@@ -157,6 +158,7 @@ class MonthView extends React.Component {
       messages,
       selected,
       now,
+      longPressThreshold,
     } = this.props
 
     const { needLimitMeasure, rowLimit } = this.state
@@ -190,6 +192,7 @@ class MonthView extends React.Component {
         eventComponent={components.event}
         eventWrapperComponent={components.eventWrapper}
         dateCellWrapper={components.dateCellWrapper}
+        longPressThreshold={longPressThreshold}
       />
     )
   }

--- a/src/Selection.js
+++ b/src/Selection.js
@@ -168,7 +168,7 @@ class Selection {
 
   _handleInitialEvent (e) {
     const { clientX, clientY, pageX, pageY } = getEventCoordinates(e);
-    var node = this.container()
+    let node = this.container()
       , collides, offsetData;
 
     // Right clicks
@@ -208,8 +208,6 @@ class Selection {
     if (result === false)
       return;
 
-    //e.preventDefault();
-
     switch (e.type) {
       case 'mousedown':
         this._onEndListener = addEventListener('mouseup', this._handleTerminatingEvent)
@@ -235,9 +233,9 @@ class Selection {
 
     if (!this._initialEventData) return;
 
-    var inRoot = !this.container || contains(this.container(), e.target);
-    var bounds = this._selectRect;
-    var click = this.isClick(pageX, pageY);
+    let inRoot = !this.container || contains(this.container(), e.target);
+    let bounds = this._selectRect;
+    let click = this.isClick(pageX, pageY);
 
     this._initialEventData = null
 
@@ -259,10 +257,10 @@ class Selection {
   }
 
   _handleMoveEvent(e) {
-    var { x, y } = this._initialEventData;
+    let { x, y } = this._initialEventData;
     const { pageX, pageY } = getEventCoordinates(e);
-    var w = Math.abs(x - pageX);
-    var h = Math.abs(y - pageY);
+    let w = Math.abs(x - pageX);
+    let h = Math.abs(y - pageY);
 
     let left = Math.min(pageX, x)
       , top = Math.min(pageY, y)
@@ -343,7 +341,7 @@ export function objectsCollide(nodeA, nodeB, tolerance = 0) {
 export function getBoundsForNode(node) {
   if (!node.getBoundingClientRect) return node;
 
-  var rect = node.getBoundingClientRect()
+  let rect = node.getBoundingClientRect()
     , left = rect.left + pageOffset('left')
     , top = rect.top + pageOffset('top');
 

--- a/src/Selection.js
+++ b/src/Selection.js
@@ -2,10 +2,10 @@ import contains from 'dom-helpers/query/contains';
 import closest from 'dom-helpers/query/closest';
 import events from 'dom-helpers/events';
 
-function addEventListener(type, handler) {
-  events.on(document, type, handler)
+function addEventListener(type, handler, target = document) {
+  events.on(target, type, handler)
   return {
-    remove(){ events.off(document, type, handler) }
+    remove(){ events.off(target, type, handler) }
   }
 }
 
@@ -18,6 +18,21 @@ export function isEvent(node, { clientX, clientY, }) {
   return !!closest(target, '.rbc-event', node)
 }
 
+function getEventCoordinates(e) {
+  let target = e;
+
+  if (e.touches && e.touches.length) {
+    target = e.touches[0];
+  }
+
+  return {
+    clientX: target.clientX,
+    clientY: target.clientY,
+    pageX: target.pageX,
+    pageY: target.pageY
+  };
+}
+
 const clickTolerance = 5;
 
 class Selection {
@@ -28,14 +43,17 @@ class Selection {
 
     this._listeners = Object.create(null);
 
-    this._mouseDown = this._mouseDown.bind(this)
-    this._mouseUp = this._mouseUp.bind(this)
-    this._openSelector = this._openSelector.bind(this)
+    this._handleInitialEvent = this._handleInitialEvent.bind(this)
+    this._handleMoveEvent = this._handleMoveEvent.bind(this)
+    this._handleTerminatingEvent = this._handleTerminatingEvent.bind(this)
     this._keyListener = this._keyListener.bind(this)
 
-    this._onMouseDownListener = addEventListener('mousedown', this._mouseDown)
+    // Fixes an iOS 10 bug where scrolling could not be prevented on the window.
+    // https://github.com/metafizzy/flickity/issues/457#issuecomment-254501356
+    this._onTouchMoveWindowListener = addEventListener('touchmove', () => {}, window);
     this._onKeyDownListener = addEventListener('keydown', this._keyListener)
     this._onKeyUpListener = addEventListener('keyup', this._keyListener)
+    this._addInitialEventListener();
   }
 
   on(type, handler) {
@@ -63,9 +81,10 @@ class Selection {
 
   teardown() {
     this.listeners = Object.create(null)
-    this._onMouseDownListener && this._onMouseDownListener.remove()
-    this._onMouseUpListener && this._onMouseUpListener.remove();
-    this._onMouseMoveListener && this._onMouseMoveListener.remove();
+    this._onTouchMoveWindowListener && this._onTouchMoveWindowListener.remove();
+    this._onInitialEventListener && this._onInitialEventListener.remove()
+    this._onEndListener && this._onEndListener.remove();
+    this._onMoveListener && this._onMoveListener.remove();
     this._onKeyUpListener && this._onKeyUpListener.remove();
     this._onKeyDownListener && this._onKeyDownListener.remove()
   }
@@ -88,7 +107,66 @@ class Selection {
     return items.filter(this.isSelected, this)
   }
 
-  _mouseDown (e) {
+  // Adds a listener that will call the handler only after the user has pressed on the screen
+  // without moving their finger for 250ms.
+  _addLongPressListener(handler, initialEvent) {
+    let timer = null;
+    let touchMoveListener = null;
+    let touchEndListener = null;
+    const handleTouchStart = (initialEvent) => {
+      timer = setTimeout(() => {
+        cleanup();
+        handler(initialEvent);
+      }, 250);
+      touchMoveListener = addEventListener('touchmove', () => cleanup());
+      touchEndListener = addEventListener('touchend', () => cleanup());
+    };
+    const touchStartListener = addEventListener('touchstart', handleTouchStart);
+    const cleanup = () => {
+      if (timer) { clearTimeout(timer); }
+      if (touchMoveListener) { touchMoveListener.remove(); }
+      if (touchEndListener) { touchEndListener.remove(); }
+
+      timer = null;
+      touchMoveListener = null;
+      touchEndListener = null;
+    }
+
+    if (initialEvent) {
+      handleTouchStart(initialEvent);
+    }
+
+    return {
+      remove() {
+        cleanup();
+        touchStartListener.remove();
+      },
+    };
+  }
+
+  // Listen for mousedown and touchstart events. When one is received, disable the other and setup
+  // future event handling based on the type of event.
+  _addInitialEventListener() {
+    const mouseDownListener = addEventListener('mousedown', (e) => {
+      this._onInitialEventListener.remove();
+      this._handleInitialEvent(e);
+      this._onInitialEventListener = addEventListener('mousedown', this._handleInitialEvent);
+    });
+    const touchStartListener = addEventListener('touchstart', (e) => {
+      this._onInitialEventListener.remove();
+      this._onInitialEventListener = this._addLongPressListener(this._handleInitialEvent, e);
+    });
+
+    this._onInitialEventListener = {
+      remove() {
+        mouseDownListener.remove();
+        touchStartListener.remove();
+      },
+    };
+  }
+
+  _handleInitialEvent (e) {
+    const { clientX, clientY, pageX, pageY } = getEventCoordinates(e);
     var node = this.container()
       , collides, offsetData;
 
@@ -96,7 +174,7 @@ class Selection {
     if (
       e.which === 3 ||
       e.button === 2 ||
-      !isOverContainer(node, e.clientX, e.clientY)
+      !isOverContainer(node, clientX, clientY)
 
     )
       return;
@@ -113,16 +191,17 @@ class Selection {
         bottom: offsetData.bottom + bottom,
         right: offsetData.right + right
       },
-      { top: e.pageY, left: e.pageX });
+      { top: pageY, left: pageX });
 
       if (!collides) return;
     }
 
-    let result = this.emit('mousedown', this._mouseDownData = {
-      x: e.pageX,
-      y: e.pageY,
-      clientX: e.clientX,
-      clientY: e.clientY
+    let result = this.emit('beforeSelect', this._initialEventData = {
+      isTouch: /^touch/.test(e.type),
+      x: pageX,
+      y: pageY,
+      clientX,
+      clientY,
     });
 
     if (result === false)
@@ -130,22 +209,36 @@ class Selection {
 
     //e.preventDefault();
 
-    this._onMouseUpListener = addEventListener('mouseup', this._mouseUp)
-    this._onMouseMoveListener = addEventListener('mousemove', this._openSelector)
+    switch (e.type) {
+      case 'mousedown':
+        this._onEndListener = addEventListener('mouseup', this._handleTerminatingEvent)
+        this._onMoveListener = addEventListener('mousemove', this._handleMoveEvent)
+        break;
+      case 'touchstart':
+        this._handleMoveEvent(e);
+        this._onEndListener = addEventListener('touchend', this._handleTerminatingEvent)
+        this._onMoveListener = addEventListener('touchmove', this._handleMoveEvent)
+        break;
+      default:
+        break;
+    }
   }
 
-  _mouseUp(e) {
+  _handleTerminatingEvent(e) {
+    const { pageX, pageY, clientX, clientY } = getEventCoordinates(e);
 
-    this._onMouseUpListener && this._onMouseUpListener.remove();
-    this._onMouseMoveListener && this._onMouseMoveListener.remove();
+    this.selecting = false;
 
-    if (!this._mouseDownData) return;
+    this._onEndListener && this._onEndListener.remove();
+    this._onMoveListener && this._onMoveListener.remove();
+
+    if (!this._initialEventData) return;
 
     var inRoot = !this.container || contains(this.container(), e.target);
     var bounds = this._selectRect;
-    var click = this.isClick(e.pageX, e.pageY);
+    var click = this.isClick(pageX, pageY);
 
-    this._mouseDownData = null
+    this._initialEventData = null
 
     if(click && !inRoot) {
       return this.emit('reset')
@@ -153,43 +246,45 @@ class Selection {
 
     if(click && inRoot)
       return this.emit('click', {
-        x: e.pageX,
-        y: e.pageY,
-        clientX: e.clientX,
-        clientY: e.clientY,
+        x: pageX,
+        y: pageY,
+        clientX: clientX,
+        clientY: clientY,
       })
 
     // User drag-clicked in the Selectable area
     if(!click)
       return this.emit('select', bounds)
-
-    this.selecting = false;
   }
 
-  _openSelector(e) {
-    var { x, y } = this._mouseDownData;
-    var w = Math.abs(x - e.pageX);
-    var h = Math.abs(y - e.pageY);
+  _handleMoveEvent(e) {
+    var { x, y } = this._initialEventData;
+    const { pageX, pageY } = getEventCoordinates(e);
+    var w = Math.abs(x - pageX);
+    var h = Math.abs(y - pageY);
 
-    let left = Math.min(e.pageX, x)
-      , top = Math.min(e.pageY, y)
+    let left = Math.min(pageX, x)
+      , top = Math.min(pageY, y)
       , old = this.selecting;
 
     this.selecting = true;
+    this._selectRect = {
+      top,
+      left,
+      x: pageX,
+      y: pageY,
+      right: left + w,
+      bottom: top + h
+    };
 
     if (!old) {
-      this.emit('selectStart', this._mouseDownData)
+      this.emit('selectStart', this._initialEventData);
     }
 
-    if (!this.isClick(e.pageX, e.pageY))
-      this.emit('selecting', this._selectRect = {
-        top,
-        left,
-        x: e.pageX,
-        y: e.pageY,
-        right: left + w,
-        bottom: top + h
-      });
+    if (!this.isClick(pageX, pageY))
+      this.emit('selecting', this._selectRect);
+
+    e.preventDefault();
   }
 
   _keyListener(e) {
@@ -197,8 +292,8 @@ class Selection {
   }
 
   isClick(pageX, pageY){
-    var { x, y } = this._mouseDownData;
-    return (
+    let { x, y, isTouch } = this._initialEventData;
+    return !isTouch && (
       Math.abs(pageX - x) <= clickTolerance &&
       Math.abs(pageY - y) <= clickTolerance
     );

--- a/src/Selection.js
+++ b/src/Selection.js
@@ -37,9 +37,10 @@ const clickTolerance = 5;
 
 class Selection {
 
-  constructor(node, global = false){
+  constructor(node, { global = false, longPressThreshold = 250 } = {}) {
     this.container = node;
     this.globalMouse = !node || global;
+    this.longPressThreshold = longPressThreshold;
 
     this._listeners = Object.create(null);
 
@@ -117,7 +118,7 @@ class Selection {
       timer = setTimeout(() => {
         cleanup();
         handler(initialEvent);
-      }, 250);
+      }, this.longPressThreshold);
       touchMoveListener = addEventListener('touchmove', () => cleanup());
       touchEndListener = addEventListener('touchend', () => cleanup());
     };

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -50,6 +50,7 @@ export default class TimeGrid extends Component {
 
     selected: PropTypes.object,
     selectable: PropTypes.oneOf([true, false, 'ignoreEvents']),
+    longPressThreshold: PropTypes.number,
 
     onNavigate: PropTypes.func,
     onSelectSlot: PropTypes.func,
@@ -276,6 +277,7 @@ export default class TimeGrid extends Component {
             eventPropGetter={this.props.eventPropGetter}
             selected={this.props.selected}
             onSelect={this.handleSelectEvent}
+            longPressThreshold={this.props.longPressThreshold}
           />
         </div>
       </div>

--- a/src/less/month.less
+++ b/src/less/month.less
@@ -38,6 +38,7 @@
   flex: 1 0 0;
   width: 100%;
   user-select: none;
+  -webkit-user-select: none;
 
   height: 100%; // ie-fix
 

--- a/src/less/styles.less
+++ b/src/less/styles.less
@@ -62,6 +62,7 @@
 .rbc-row-content {
   position: relative;
   user-select: none;
+  -webkit-user-select: none;
   z-index: 4;
 }
 

--- a/src/less/time-grid.less
+++ b/src/less/time-grid.less
@@ -100,6 +100,7 @@
   > .rbc-day-slot {
     width: 100%;
     user-select: none;
+    -webkit-user-select: none;
   }
 }
 


### PR DESCRIPTION
This PR adds support for touch events when "selectable" is enabled. The
selection box appears after the user presses and holds on the screen
for 250ms as to not interfere with scrolling. This is similar to how the native iOS calendar behaves.

I ended up reorganizing/renaming some things in `Selectable.js` to make things make more sense in the context that it is not necessarily _mouse_ events that are being handled.

I'm looking forward to your feedback on this, and am happy to make any changes you suggest! Cheers!

Fixes #38.