### PR TITLE
Fix for marking date as 'now'

### DIFF
--- a/src/DateContentRow.js
+++ b/src/DateContentRow.js
@@ -31,7 +31,7 @@ const propTypes = {
   onSelectEnd: PropTypes.func,
   onSelectStart: PropTypes.func,
 
-  now: PropTypes.instanceOf(Date),
+  now: PropTypes.instanceOf(Date).isRequired,
   startAccessor: accessor.isRequired,
   endAccessor: accessor.isRequired,
 

--- a/src/Month.js
+++ b/src/Month.js
@@ -78,6 +78,10 @@ class MonthView extends React.Component {
   static displayName = 'MonthView'
   static propTypes = propTypes
 
+  static defaultProps = {
+    now: new Date()
+  }
+
   constructor(...args) {
     super(...args)
 


### PR DESCRIPTION
Default 'now' prop in Month view so that the .rbc-now class is correctly added to the current date when the 'now' prop isn't supplied to the Calendar.