### PR TITLE
Option to show multi-day events with specific start and end times in time-slots

### DIFF
--- a/examples/demos/basic.js
+++ b/examples/demos/basic.js
@@ -12,6 +12,7 @@ let Basic = React.createClass({
         events={events}
         views={allViews}
         defaultDate={new Date(2015, 3, 1)}
+        showMultiDayTimes={true}
       />
     )
   }

--- a/examples/demos/basic.js
+++ b/examples/demos/basic.js
@@ -12,7 +12,6 @@ let Basic = React.createClass({
         events={events}
         views={allViews}
         defaultDate={new Date(2015, 3, 1)}
-        showMultiDayTimes={true}
       />
     )
   }

--- a/examples/events.js
+++ b/examples/events.js
@@ -66,5 +66,15 @@ export default [
     'title': 'Birthday Party',
     'start':new Date(2015, 3, 13, 7, 0, 0),
     'end': new Date(2015, 3, 13, 10, 30, 0)
+  },
+  {
+    'title': 'Late Night Event',
+    'start':new Date(2015, 3, 17, 19, 30, 0),
+    'end': new Date(2015, 3, 18, 2, 0, 0)
+  },
+  {
+    'title': 'Multi-day Event',
+    'start':new Date(2015, 3, 20, 19, 30, 0),
+    'end': new Date(2015, 3, 22, 2, 0, 0)
   }
 ]

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -12,6 +12,7 @@ import {
 import { notify } from './utils/helpers';
 import { navigate, views } from './utils/constants';
 import defaultFormats from './formats';
+import message from './utils/messages'
 import viewLabel from './utils/viewLabel';
 import moveDate from './utils/move';
 import VIEWS from './Views';
@@ -513,6 +514,7 @@ class Calendar extends React.Component {
      , culture
      , components = {}
      , formats = {}
+     , messages = {}
      , style
      , className
      , elementProps
@@ -520,6 +522,7 @@ class Calendar extends React.Component {
      , ...props } = this.props;
 
    formats = defaultFormats(formats)
+   messages = message(messages)
 
    let View = this.getView();
    let names = viewNames(this.props.views)
@@ -552,13 +555,14 @@ class Calendar extends React.Component {
            label={viewLabel(current, view, formats, culture)}
            onViewChange={this.handleViewChange}
            onNavigate={this.handleNavigate}
-           messages={this.props.messages}
+           messages={messages}
          />
        }
        <View
          ref='view'
          {...props}
          {...formats}
+         messages={messages}
          culture={culture}
          formats={undefined}
          events={events}

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -289,6 +289,14 @@ class Calendar extends React.Component {
    endAccessor: accessor,
 
    /**
+    * Support to show multi-day events with specific start and end times. This
+    * will show these events in the week and day views throughout the day instead of
+    * in the all-day header. Note that if a day has multiple days in between the start
+    * and end dates, with this enabled the even will span throughout the entire day.
+    */
+   showMultiDayTimes: PropTypes.bool,
+
+   /**
     * Constrains the minimum _time_ of the Day and Week views.
     */
    min: PropTypes.instanceOf(Date),

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -289,10 +289,11 @@ class Calendar extends React.Component {
    endAccessor: accessor,
 
    /**
-    * Support to show multi-day events with specific start and end times. This
-    * will show these events in the week and day views throughout the day instead of
-    * in the all-day header. Note that if a day has multiple days in between the start
-    * and end dates, with this enabled the even will span throughout the entire day.
+    * Support to show multi-day events with specific start and end times in the
+    * main time grid (rather than in the all day header).
+    *
+    * **Note: This may cause calendars with several events to look very busy in
+    * the week and day views.**
     */
    showMultiDayTimes: PropTypes.bool,
 

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -152,13 +152,13 @@ class DaySlot extends React.Component {
       let start = get(event, startAccessor)
       let end = get(event, endAccessor)
 
-      if (start < min && end <= max) {
+      if (start < min) {
         start = min;
         _continuesPrior = true;
         _eventTimeRangeFormat = eventTimeRangeEndFormat;
       }
 
-      if (end > max && start >= min) {
+      if (end > max) {
         end = max;
         _continuesAfter = true;
         _eventTimeRangeFormat = eventTimeRangeStartFormat;
@@ -169,10 +169,8 @@ class DaySlot extends React.Component {
 
       let title = get(event, titleAccessor)
       let label;
-      if (start < min && end > max) {
+      if (_continuesPrior && _continuesAfter) {
         label = messages.allDay;
-        _continuesPrior = true;
-        _continuesAfter = true;
       } else {
           label = localizer.format({start, end}, _eventTimeRangeFormat, culture);
       }

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -41,6 +41,7 @@ class DaySlot extends React.Component {
 
     selectRangeFormat: dateFormat,
     eventTimeRangeFormat: dateFormat,
+    showMultiDayTimes: PropTypes.bool,
     culture: PropTypes.string,
 
     selected: PropTypes.object,
@@ -128,6 +129,7 @@ class DaySlot extends React.Component {
         events
       , min
       , max
+      , showMultiDayTimes
       , culture
       , eventPropGetter
       , selected, messages, eventTimeRangeFormat, eventComponent
@@ -140,7 +142,7 @@ class DaySlot extends React.Component {
     let EventComponent = eventComponent
 
     let styledEvents = getStyledEvents({
-      events, startAccessor, endAccessor, min, totalMin: this._totalMin, step
+      events, startAccessor, endAccessor, min, showMultiDayTimes, totalMin: this._totalMin, step
     })
 
     return styledEvents.map(({ event, style }, idx) => {
@@ -150,15 +152,16 @@ class DaySlot extends React.Component {
       let start = get(event, startAccessor)
       let end = get(event, endAccessor)
 
-      if (start < min) {
-          start = min;
-          _continuesPrior = true;
-          _eventTimeRangeFormat = eventTimeRangeEndFormat;
+      if (start < min && end <= max) {
+        start = min;
+        _continuesPrior = true;
+        _eventTimeRangeFormat = eventTimeRangeEndFormat;
       }
-      if (end > max) {
-          end = max;
-          _continuesAfter = true;
-          _eventTimeRangeFormat = eventTimeRangeStartFormat;
+
+      if (end > max && start >= min) {
+        end = max;
+        _continuesAfter = true;
+        _eventTimeRangeFormat = eventTimeRangeStartFormat;
       }
 
       let continuesPrior = startsBefore(start, min)
@@ -166,8 +169,10 @@ class DaySlot extends React.Component {
 
       let title = get(event, titleAccessor)
       let label;
-      if (_continuesPrior && _continuesAfter) {
-          label = messages.allDay;
+      if (start < min && end > max) {
+        label = messages.allDay;
+        _continuesPrior = true;
+        _continuesAfter = true;
       } else {
           label = localizer.format({start, end}, _eventTimeRangeFormat, culture);
       }

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -38,6 +38,7 @@ export default class TimeGrid extends Component {
     scrollToTime: PropTypes.instanceOf(Date),
     eventPropGetter: PropTypes.func,
     dayFormat: dateFormat,
+    showMultiDayTimes: PropTypes.bool,
     culture: PropTypes.string,
 
     rtl: PropTypes.bool,
@@ -141,7 +142,8 @@ export default class TimeGrid extends Component {
       , width
       , startAccessor
       , endAccessor
-      , allDayAccessor } = this.props;
+      , allDayAccessor
+      , showMultiDayTimes} = this.props;
 
     width = width || this.state.gutterWidth;
 
@@ -158,14 +160,13 @@ export default class TimeGrid extends Component {
         let eStart = get(event, startAccessor)
           , eEnd = get(event, endAccessor);
 
-        if (
-          get(event, allDayAccessor)
-          || (dates.isJustDate(eStart) && (dates.isJustDate(eEnd) || dates.isJustDate(dates.add(eEnd, 1, 'millisecond')))))
-        {
+        if (get(event, allDayAccessor)
+          || (dates.isJustDate(eStart) && dates.isJustDate(eEnd))
+          || (!showMultiDayTimes && !dates.eq(eStart, eEnd, 'day'))) {
           allDayEvents.push(event)
-        }
-        else
+        } else {
           rangeEvents.push(event)
+        }
       }
     })
 

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -160,8 +160,7 @@ export default class TimeGrid extends Component {
 
         if (
           get(event, allDayAccessor)
-          || !dates.eq(eStart, eEnd, 'day')
-          || (dates.isJustDate(eStart) && dates.isJustDate(eEnd)))
+          || (dates.isJustDate(eStart) && (dates.isJustDate(eEnd) || dates.isJustDate(dates.add(eEnd, 1, 'millisecond')))))
         {
           allDayEvents.push(event)
         }

--- a/src/Toolbar.js
+++ b/src/Toolbar.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import cn from 'classnames';
-import message from './utils/messages';
 import { navigate } from './utils/constants';
 
 class Toolbar extends React.Component {
@@ -18,8 +17,6 @@ class Toolbar extends React.Component {
 
   render() {
     let { messages, label } = this.props;
-
-    messages = message(messages)
 
     return (
       <div className='rbc-toolbar'>

--- a/src/formats.js
+++ b/src/formats.js
@@ -13,6 +13,12 @@ let timeRangeFormat = ({ start, end }, culture, local)=>
   local.format(start, 'h:mmtt', culture) +
     ' — ' + local.format(end, inSame12Hr(start, end) ? 'h:mm' : 'h:mmtt', culture)
 
+let timeRangeStartFormat = ({ start, end }, culture, local)=>
+  local.format(start, 'h:mmtt', culture) +' — '
+
+let timeRangeEndFormat = ({ start, end }, culture, local)=>
+  ' — ' + local.format(end, 'h:mmtt', culture)
+
 let weekRangeFormat = ({ start, end }, culture, local)=>
   local.format(start, 'MMM dd', culture) +
     ' - ' + local.format(end, dates.eq(start, end, 'month') ? 'dd' : 'MMM dd', culture)
@@ -25,6 +31,8 @@ let formats = {
 
   selectRangeFormat: timeRangeFormat,
   eventTimeRangeFormat: timeRangeFormat,
+  eventTimeRangeStartFormat: timeRangeStartFormat,
+  eventTimeRangeEndFormat: timeRangeEndFormat,
 
   timeGutterFormat: 'h:mm tt',
 

--- a/src/less/event.less
+++ b/src/less/event.less
@@ -39,3 +39,13 @@
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
 }
+
+.rbc-event-continues-day-after {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.rbc-event-continues-day-prior {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}

--- a/src/localizers/globalize.js
+++ b/src/localizers/globalize.js
@@ -11,6 +11,12 @@ let timeRangeFormat = ({ start, end }, culture, local) =>
   local.format(start, { time: 'short' }, culture) +
     ' — ' + local.format(end, { time: 'short' }, culture)
 
+let timeRangeStartFormat = ({ start, end }, culture, local)=>
+local.format(start, { time: 'short' }, culture) + ' — '
+
+let timeRangeEndFormat = ({ start, end }, culture, local)=>
+' — ' + local.format(end, { time: 'short' }, culture)
+
 let weekRangeFormat = ({ start, end }, culture, local) =>
   local.format(start, 'MMM dd', culture) +
     ' — ' + local.format(end, dates.eq(start, end, 'month') ? 'dd' : 'MMM dd', culture)
@@ -22,6 +28,8 @@ export let formats = {
 
   selectRangeFormat: timeRangeFormat,
   eventTimeRangeFormat: timeRangeFormat,
+  eventTimeRangeStartFormat: timeRangeStartFormat,
+  eventTimeRangeEndFormat: timeRangeEndFormat,
 
   timeGutterFormat: { time: 'short' },
 

--- a/src/localizers/moment.js
+++ b/src/localizers/moment.js
@@ -8,6 +8,12 @@ let dateRangeFormat = ({ start, end }, culture, local)=>
 let timeRangeFormat = ({ start, end }, culture, local) =>
   local.format(start, 'LT', culture) + ' — ' + local.format(end, 'LT', culture)
 
+let timeRangeStartFormat = ({ start, end }, culture, local)=>
+  local.format(start, 'h:mma', culture) +' — '
+
+let timeRangeEndFormat = ({ start, end }, culture, local)=>
+  ' — ' + local.format(end, 'h:mma', culture)
+
 let weekRangeFormat = ({ start, end }, culture, local)=>
   local.format(start, 'MMM DD', culture) +
     ' - ' + local.format(end, dates.eq(start, end, 'month') ? 'DD' : 'MMM DD', culture)
@@ -19,6 +25,8 @@ export let formats = {
 
   selectRangeFormat: timeRangeFormat,
   eventTimeRangeFormat: timeRangeFormat,
+  eventTimeRangeStartFormat: timeRangeStartFormat,
+  eventTimeRangeEndFormat: timeRangeEndFormat,
 
   timeGutterFormat: 'LT',
 

--- a/src/localizers/oldGlobalize.js
+++ b/src/localizers/oldGlobalize.js
@@ -9,6 +9,12 @@ let timeRangeFormat = ({ start, end }, culture, local)=>
   local.format(start, 't', culture) +
     ' — ' + local.format(end, 't', culture)
 
+let timeRangeStartFormat = ({ start, end }, culture, local)=>
+  local.format(start, 't', culture) + ' — '
+
+let timeRangeEndFormat = ({ start, end }, culture, local)=>
+  ' — ' + local.format(end, 't', culture)
+
 let weekRangeFormat = ({ start, end }, culture, local)=>
   local.format(start, 'MMM dd', culture) +
     ' - ' + local.format(end, dates.eq(start, end, 'month') ? 'dd' : 'MMM dd', culture)
@@ -20,6 +26,8 @@ export let formats = {
 
   selectRangeFormat: timeRangeFormat,
   eventTimeRangeFormat: timeRangeFormat,
+  eventTimeRangeStartFormat: timeRangeStartFormat,
+  eventTimeRangeEndFormat: timeRangeEndFormat,
 
   timeGutterFormat: 't',
 

--- a/src/utils/dayViewLayout.js
+++ b/src/utils/dayViewLayout.js
@@ -136,12 +136,12 @@ let handleMultiDayEvents = (title, start, end, current) => {
 
   // if current day is at the start, but spans multiple days, correct the end
   if (c === s && c < e) {
-    return constructEvent(title, start, new Date(current.getYear(), current.getMonth(), c, 23, 59, 59, 59))
+    return constructEvent(title, start, dates.endOf(start, 'day'))
   }
 
   // if current day is in between start and end dates, span all day
   else if (c > s && c < e) {
-    return constructEvent(title, current, new Date(current.getYear(), current.getMonth(), c, 23, 59, 59, 59))
+    return constructEvent(title, current, dates.endOf(current, 'day'))
   }
 
   // if current day is at the end of a multi day event, start at midnight

--- a/src/utils/dayViewLayout.js
+++ b/src/utils/dayViewLayout.js
@@ -231,7 +231,7 @@ export default function getStyledEvents ({
     [idx, ...siblings].forEach((eventIdx, siblingIdx) => {
       let width = 100 / nbrOfColumns
       let xAdjustment = width * (nbrOfColumns > 1 ? OVERLAP_MULTIPLIER : 0)
-      let { top, height } = getYStyles(eventIdx, helperArgs, min)
+      let { top, height } = getYStyles(eventIdx, helperArgs)
 
       styledEvents[eventIdx] = {
         event: events[eventIdx],

--- a/src/utils/dayViewLayout.js
+++ b/src/utils/dayViewLayout.js
@@ -130,12 +130,17 @@ let constructEvent = (title, start, end) => {
 }
 
 let handleMultiDayEvents = (title, start, end, current) => {
-  let s = new Date(start).getDate()
-  let e = new Date(end).getDate()
-  let c = new Date(current).getDate()
+  let s = new Date(start)
+  let e = new Date(end)
+  let c = new Date(current)
+
+  // use noon to compare dates to avoid DST issues
+  s.setHours(12, 0, 0, 0)
+  e.setHours(12, 0, 0, 0)
+  c.setHours(12, 0, 0, 0)
 
   // if current day is at the start, but spans multiple days, correct the end
-  if (c === s && c < e) {
+  if (+c === +s && c < e) {
     return constructEvent(title, start, dates.endOf(start, 'day'))
   }
 
@@ -145,7 +150,7 @@ let handleMultiDayEvents = (title, start, end, current) => {
   }
 
   // if current day is at the end of a multi day event, start at midnight to the end
-  else if (c > s && c === e) {
+  else if (c > s && +c === +e) {
     return constructEvent(title, current, end)
   }
 }

--- a/src/utils/dayViewLayout.js
+++ b/src/utils/dayViewLayout.js
@@ -144,14 +144,9 @@ let handleMultiDayEvents = (title, start, end, current) => {
     return constructEvent(title, current, dates.endOf(current, 'day'))
   }
 
-  // if current day is at the end of a multi day event, start at midnight
+  // if current day is at the end of a multi day event, start at midnight to the end
   else if (c > s && c === e) {
     return constructEvent(title, current, end)
-  }
-
-  // else, construct a normal event
-  else {
-    return constructEvent(title, start, end)
   }
 }
 
@@ -160,18 +155,21 @@ let handleMultiDayEvents = (title, start, end, current) => {
  * the specified index.
  */
 let getYStyles = (idx, {
-  events, startAccessor, endAccessor, min, totalMin, step
+  events, startAccessor, endAccessor, min, showMultiDayTimes, totalMin, step
 }) => {
   let event = events[idx]
 
   let startDate = get(event, startAccessor) // start date
   let endDate = get(event, endAccessor) // end date
-  let currentDate = new Date(min) // min is the current date at 00:00
+  let currentDate = new Date(min) // min is the current date at midnight
 
-  let newEvent = handleMultiDayEvents(event.title, startDate, endDate, currentDate)
+  let multiDayEvent = {}
+  if (showMultiDayTimes) {
+    multiDayEvent = handleMultiDayEvents(event.title, startDate, endDate, currentDate)
+  }
 
-  let start = getSlot(newEvent, startAccessor, min, totalMin)
-  let end = Math.max(getSlot(newEvent, endAccessor, min, totalMin), start + step)
+  let start = getSlot(multiDayEvent || event, startAccessor, min, totalMin)
+  let end = Math.max(getSlot(multiDayEvent || event, endAccessor, min, totalMin), start + step)
   let top = start / totalMin * 100
   let bottom = end / totalMin * 100
 
@@ -211,11 +209,11 @@ let getYStyles = (idx, {
  * traversed, so the cursor will be moved past all of them.
  */
 export default function getStyledEvents ({
-  events: unsortedEvents, startAccessor, endAccessor, min, totalMin, step
+  events: unsortedEvents, startAccessor, endAccessor, min, showMultiDayTimes, totalMin, step
 }) {
   let OVERLAP_MULTIPLIER = 0.3
   let events = sort(unsortedEvents, { startAccessor, endAccessor })
-  let helperArgs = { events, startAccessor, endAccessor, min, totalMin, step }
+  let helperArgs = { events, startAccessor, endAccessor, min, showMultiDayTimes, totalMin, step }
   let styledEvents = []
   let idx = 0
 

--- a/src/utils/dayViewLayout.js
+++ b/src/utils/dayViewLayout.js
@@ -129,14 +129,47 @@ let getYStyles = (idx, {
   events, startAccessor, endAccessor, min, totalMin, step
 }) => {
   let event = events[idx]
+
+  let startDate = get(event, startAccessor) // start date
+  let endDate = get(event, endAccessor) // end date
+  let currentDate = new Date(min) // min is the current date at 00:00
+
+  let s = new Date(startDate).getDate()
+  let e = new Date(endDate).getDate()
+  let c = new Date(currentDate).getDate()
+
+  // if current day is at the start, but spans multiple days, correct the end
+  if (c === s && c < e) {
+    console.log('start day')
+    // event.end = currentDate + 1
+  }
+
+  // if current day is in between start and end dates, span all day
+  if (c > s && c < e) {
+    console.log('middle day')
+    event.start = currentDate
+    event.end = currentDate + 1
+  }
+
+  // if current day is at the end of a multi day event, start at midnight
+  if (c > s && c === e) {
+    console.log('end day')
+    event.start = currentDate
+  }
+
   let start = getSlot(event, startAccessor, min, totalMin)
   let end = Math.max(getSlot(event, endAccessor, min, totalMin), start + step)
   let top = start / totalMin * 100
   let bottom = end / totalMin * 100
 
+  let height = bottom - top
+
+  event.start = startDate
+  event.end = endDate
+
   return {
     top,
-    height: bottom - top
+    height
   }
 }
 
@@ -188,7 +221,7 @@ export default function getStyledEvents ({
     [idx, ...siblings].forEach((eventIdx, siblingIdx) => {
       let width = 100 / nbrOfColumns
       let xAdjustment = width * (nbrOfColumns > 1 ? OVERLAP_MULTIPLIER : 0)
-      let { top, height } = getYStyles(eventIdx, helperArgs)
+      let { top, height } = getYStyles(eventIdx, helperArgs, min)
 
       styledEvents[eventIdx] = {
         event: events[eventIdx],


### PR DESCRIPTION
Added the config option `showMultiDayTimes` to show multi-day events with defined start and end times to show in the time slot views as opposed to the all-day header.

However there were limitations in doing this as all day events and time range events are rendered as separate objects, so when there is an 'in-between' day in the multi-day event, this will take up the entire time slot view for the given days. I found this to be more desirable, because if it were that way, then clicking on the all day object would not link to the rest of the days in the event.

The bulk of this work is from PR #42 but I have updated it with the new styling changes from the past year, as well as made this feature a configurable option.