### PR TITLE
Fix prop types validation when passing object to views

### DIFF
--- a/src/utils/propTypes.js
+++ b/src/utils/propTypes.js
@@ -64,7 +64,7 @@ export let views = PropTypes.oneOfType([
   PropTypes.arrayOf(
     PropTypes.oneOf(viewNames)
   ),
-  all([
+  all(
     PropTypes.object,
     (props, name, ...args)=>{
       let prop = props[name]
@@ -80,5 +80,5 @@ export let views = PropTypes.oneOfType([
 
       return err || null
     }
-  ])
+  )
 ])


### PR DESCRIPTION
When passing object to `views` property, there is an error in browser: 

```
Warning: Failed prop type: validator.apply is not a function
```

The reason is incorrect usage of [react-prop-types#all](https://github.com/react-bootstrap/react-prop-types#allvalidators), which spreads args, but does not handle arrays.

Component itself continues to work fine though.