### PR TITLE
Render overnight events in time grid view

### DIFF
--- a/examples/events.js
+++ b/examples/events.js
@@ -66,5 +66,15 @@ export default [
     'title': 'Birthday Party',
     'start':new Date(2015, 3, 13, 7, 0, 0),
     'end': new Date(2015, 3, 13, 10, 30, 0)
+  },
+  {
+    'title': 'Multiday Event',
+    'start':new Date(2015, 3, 15, 0, 0, 0),
+    'end': new Date(2015, 3, 16, 23, 0, 0)
+  },
+  {
+    'title': '1 min event',
+    'start':new Date(2015, 3, 12, 0, 0, 0),
+    'end': new Date(2015, 3, 12, 0, 1, 0)
   }
 ]

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -22,8 +22,6 @@ import { accessor as get } from './utils/accessors';
 
 import { inRange, sortEvents, segStyle } from './utils/eventLevels';
 
-window.dates = dates;
-
 export default class TimeGrid extends Component {
 
   static propTypes = {

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -22,6 +22,8 @@ import { accessor as get } from './utils/accessors';
 
 import { inRange, sortEvents, segStyle } from './utils/eventLevels';
 
+window.dates = dates;
+
 export default class TimeGrid extends Component {
 
   static propTypes = {
@@ -164,6 +166,7 @@ export default class TimeGrid extends Component {
           || (dates.isJustDate(eStart) && dates.isJustDate(eEnd)))
         {
           allDayEvents.push(event)
+          rangeEvents.push(event)
         }
         else
           rangeEvents.push(event)

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -155,6 +155,14 @@ let dates = {
 
   tomorrow() {
     return dates.add(dates.startOf(new Date(), 'day'), 1, 'day')
+  },
+
+  isBefore(dateA, dateB, unit) {
+    return dates.diff(dateA, dateB, unit) !== 0 && dates.lt(dateA, dateB);
+  },
+
+  isAfter(dateA, dateB, unit) {
+    return dates.diff(dateA, dateB, unit) !== 0 && dates.gt(dateA, dateB);
   }
 }
 

--- a/src/utils/dayViewLayout.js
+++ b/src/utils/dayViewLayout.js
@@ -121,6 +121,16 @@ let getChildGroups = (idx, nextIdx, {
   return { childGroups: groups, nbrOfChildColumns: nbrOfColumns }
 }
 
+let startsBeforeDay = (event, min, startAccessor) => {
+  const startDate = get(event, startAccessor)
+  return dates.isBefore(startDate, min, 'day')
+}
+
+let endsNextDay = (event, min, endAccessor) => {
+  const endDate = get(event, endAccessor)
+  return dates.isAfter(endDate, min, 'day')
+}
+
 /**
  * Returns height and top offset, both in percentage, for an event at
  * the specified index.
@@ -129,8 +139,15 @@ let getYStyles = (idx, {
   events, startAccessor, endAccessor, min, totalMin, step
 }) => {
   let event = events[idx]
-  let start = getSlot(event, startAccessor, min, totalMin)
-  let end = Math.max(getSlot(event, endAccessor, min, totalMin), start + step)
+
+  let start = startsBeforeDay(event, min, startAccessor)
+    ? 0
+    : getSlot(event, startAccessor, min, totalMin)
+
+  let end = endsNextDay(event, min, endAccessor)
+    ? totalMin
+    : Math.max(getSlot(event, endAccessor, min, totalMin), start + step)
+
   let top = start / totalMin * 100
   let bottom = end / totalMin * 100
 


### PR DESCRIPTION
This should make it possible to render overnight events that span multiple days. The event which spans multiple days is added to the `rangeEvents`, so it appears in both "all day events" and in the "time grid" views. I haven't yet added any props to configure this behaviour, as I was not sure if this solution is good. 

References #461 