### PR TITLE
Prevent popup growing up outside of calendar

### DIFF
--- a/src/Popup.js
+++ b/src/Popup.js
@@ -48,7 +48,7 @@ class Popup extends React.Component {
       , leftOffset = (this.state || {}).leftOffset || 0;
 
     let style = {
-      top: top - topOffset,
+      top: Math.max(0, top - topOffset),
       left: left - leftOffset,
       minWidth: width + (width / 2)
     }


### PR DESCRIPTION
Prevent popup growing up outside of calendar. Before this change, the logic is when overlay reaches bottom it will grow up.

If there are too many events in a day, when the overlay reaches the bottom it can grow up outside calendar since the top can be a very big negative number. In this case I can't scroll to view hidden events.

<img width="342" alt="bad top" src="https://user-images.githubusercontent.com/3725560/29791036-777fff30-8bf0-11e7-89e3-e91c781efaa9.png">
<img width="1332" alt="bad view" src="https://user-images.githubusercontent.com/3725560/29791037-778982b2-8bf0-11e7-975f-18ce84497294.png">

After this change, the logic is when overlay reaches bottom it will grow up until it reaches the top of calendar, then it grows downward. So I can scroll down to view other events.

<img width="1335" alt="view2" src="https://user-images.githubusercontent.com/3725560/29791182-ecd8ef80-8bf0-11e7-9e62-dac081be77bb.png">
<img width="1329" alt="view1" src="https://user-images.githubusercontent.com/3725560/29791184-ecf45afe-8bf0-11e7-8797-241e174e4cea.png">