### PR TITLE
Fix timeGutterFormat propTypes

### DIFF
--- a/src/TimeColumn.js
+++ b/src/TimeColumn.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import cn from 'classnames';
 
 import dates from './utils/dates';
-import { elementType } from './utils/propTypes';
+import { elementType, dateFormat } from './utils/propTypes';
 import BackgroundWrapper from './BackgroundWrapper';
 import TimeSlotGroup from './TimeSlotGroup'
 
@@ -16,7 +16,7 @@ export default class TimeColumn extends Component {
     min: PropTypes.instanceOf(Date).isRequired,
     max: PropTypes.instanceOf(Date).isRequired,
     showLabels: PropTypes.bool,
-    timeGutterFormat: PropTypes.string,
+    timeGutterFormat: dateFormat,
     type: PropTypes.string.isRequired,
     className: PropTypes.string,
 

--- a/src/TimeSlotGroup.js
+++ b/src/TimeSlotGroup.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import TimeSlot from './TimeSlot'
 import date from './utils/dates.js'
 import localizer from './localizer'
-import { elementType } from './utils/propTypes'
+import { elementType, dateFormat } from './utils/propTypes'
 
 export default class TimeSlotGroup extends Component {
   static propTypes = {
@@ -14,7 +14,7 @@ export default class TimeSlotGroup extends Component {
     showLabels: PropTypes.bool,
     isNow: PropTypes.bool,
     slotPropGetter: PropTypes.func,
-    timeGutterFormat: PropTypes.string,
+    timeGutterFormat: dateFormat,
     culture: PropTypes.string
   }
   static defaultProps = {


### PR DESCRIPTION
#316

Uses the dateFormat propType from `utils/propTypes`, which matches the PropType for the timeGutterFormat in `Calendar.js`

Thanks for react-big-calendar!