### PR TITLE
Feature/resizable

### DIFF
--- a/examples/App.js
+++ b/examples/App.js
@@ -20,6 +20,7 @@ import Rendering from './demos/rendering';
 import CustomView from './demos/customView';
 import Timeslots from './demos/timeslots';
 import Dnd from './demos/dnd';
+import Resizable from './demos/resizable';
 
 let demoRoot = 'https://github.com/intljusticemission/react-big-calendar/tree/master/examples/demos'
 
@@ -41,6 +42,7 @@ const Example = React.createClass({
       customView: CustomView,
       timeslots: Timeslots,
       dnd: Dnd,
+      resizable: Resizable,
     }[selected];
 
     return (
@@ -92,6 +94,9 @@ const Example = React.createClass({
               */}
               <li className={cn({active: selected === 'dnd' })}>
                 <a href='#' onClick={this.select.bind(null, 'dnd')}>Drag and Drop</a>
+              </li>
+              <li className={cn({active: selected === 'resizable' })}>
+                <a href='#' onClick={this.select.bind(null, 'resizable')}>Resizable</a>
               </li>
             </ul>
           </header>

--- a/examples/demos/dnd.js
+++ b/examples/demos/dnd.js
@@ -17,22 +17,6 @@ class Dnd extends React.Component {
     }
 
     this.moveEvent = this.moveEvent.bind(this)
-    this.resizeEvent = this.resizeEvent.bind(this)
-  }
-  resizeEvent({originalEvent, startDate, endDate}){
-    const { events } = this.state;
-
-    const idx = events.indexOf(originalEvent);
-
-    originalEvent.start = startDate;
-    originalEvent.end = endDate;
-
-    const nextEvents = [...events]
-    nextEvents.splice(idx, 1, originalEvent)
-
-    this.setState({
-      events: nextEvents
-    })
   }
 
   moveEvent({ event, start, end }) {
@@ -55,9 +39,6 @@ class Dnd extends React.Component {
     return (
       <DragAndDropCalendar
         selectable
-        resizable
-        onResizing={this.resizeEvent}
-        onResizeInit={() => true}
         events={this.state.events}
         onEventDrop={this.moveEvent}
         defaultView='week'

--- a/examples/demos/dnd.js
+++ b/examples/demos/dnd.js
@@ -17,6 +17,22 @@ class Dnd extends React.Component {
     }
 
     this.moveEvent = this.moveEvent.bind(this)
+    this.resizeEvent = this.resizeEvent.bind(this)
+  }
+  resizeEvent({originalEvent, startDate, endDate}){
+    const { events } = this.state;
+
+    const idx = events.indexOf(originalEvent);
+
+    originalEvent.start = startDate;
+    originalEvent.end = endDate;
+
+    const nextEvents = [...events]
+    nextEvents.splice(idx, 1, originalEvent)
+
+    this.setState({
+      events: nextEvents
+    })
   }
 
   moveEvent({ event, start, end }) {
@@ -39,6 +55,9 @@ class Dnd extends React.Component {
     return (
       <DragAndDropCalendar
         selectable
+        resizable
+        onResizing={this.resizeEvent}
+        onResizeInit={() => true}
         events={this.state.events}
         onEventDrop={this.moveEvent}
         defaultView='week'

--- a/examples/demos/resizable.js
+++ b/examples/demos/resizable.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import BigCalendar from 'react-big-calendar';
+import events from '../events';
+
+class Resizable extends React.Component {
+
+  constructor (props) {
+    super(props)
+    this.state = {
+      events: events
+    }
+
+    this.moveEvent = this.moveEvent.bind(this)
+  }
+  moveEvent({originalEvent, startDate, endDate}){
+    const { events } = this.state;
+
+    const idx = events.indexOf(originalEvent);
+
+    originalEvent.start = startDate;
+    originalEvent.end = endDate;
+
+    const nextEvents = [...events]
+    nextEvents.splice(idx, 1, originalEvent)
+
+    this.setState({
+      events: nextEvents
+    })
+  }
+  render(){
+    return (
+      <div {...this.props}>
+        <h3 className="callout">
+          Click an event to see more info, or
+          drag the mouse over the calendar to select a date/time range.
+        </h3>
+        <BigCalendar
+          selectable
+          resizable
+          onResizing={this.moveEvent}
+          onResizeInit={() => true}
+          events={events}
+          defaultView='week'
+          scrollToTime={new Date(1970, 1, 1, 6)}
+          defaultDate={new Date(2015, 3, 12)}
+          onSelectEvent={event => alert(event.title)}
+          onSelectSlot={(slotInfo) => alert(
+            `selected slot: \n\nstart ${slotInfo.start.toLocaleString()} ` +
+            `\nend: ${slotInfo.end.toLocaleString()}`
+          )}
+        />
+      </div>
+    )
+  }
+}
+
+export default Resizable;

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -122,6 +122,30 @@ class Calendar extends React.Component {
    onSelectEvent: PropTypes.func,
 
    /**
+    * Callback fired when a calendar event is resized.
+    *
+    * ```js
+    * (event: Object, e: SyntheticEvent) => any
+    * ```
+    *
+    * @controllable resize
+    */
+   onResizeInit: PropTypes.func,
+   onResizing: PropTypes.func,
+   onResizeEnd: PropTypes.func,
+
+   /**
+    * Callback fired when dragging an event in the Day column view.
+    *
+    * Returning `false` from the handler will prevent a resize.
+    *
+    * ```js
+    * (range: { start: Date, end: Date }) => ?boolean
+    * ```
+    */
+   onSelecting: PropTypes.func,
+
+   /**
     * Callback fired when dragging a selection in the Time views.
     *
     * Returning `false` from the handler will prevent a selection.
@@ -209,6 +233,11 @@ class Calendar extends React.Component {
     * logic
     */
    selectable: PropTypes.oneOf([true, false, 'ignoreEvents']),
+
+   /**
+    * Allows resizing.
+    */
+   resizable: PropTypes.oneOf([true, false]),
 
    /**
     * Determines the selectable time increments in week and day views
@@ -583,6 +612,7 @@ class Calendar extends React.Component {
          getDrilldownView={this.getDrilldownView}
          onNavigate={this.handleNavigate}
          onDrillDown={this.handleDrillDown}
+         onResizeEvent={this.handleResizeEvent}
          onSelectEvent={this.handleSelectEvent}
          onSelectSlot={this.handleSelectSlot}
          onShowMore={this._showMore}
@@ -603,6 +633,10 @@ class Calendar extends React.Component {
  handleViewChange = (view) => {
    if (view !== this.props.view && isValidView(view, this.props))
      this.props.onView(view)
+ };
+
+ handleResizeEvent = (...args) => {
+    notify(this.props.onResizeEvent, args)
  };
 
  handleSelectEvent = (...args) => {

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -122,16 +122,26 @@ class Calendar extends React.Component {
    onSelectEvent: PropTypes.func,
 
    /**
-    * Callback fired when a calendar event is resized.
+    * Callback fired when mousedown occurs on resize element
+    * return false to cancel
     *
     * ```js
-    * (event: Object, e: SyntheticEvent) => any
-    * ```
-    *
-    * @controllable resize
+    * ({originalEvent: event}) => ?boolean
     */
    onResizeInit: PropTypes.func,
+   /**
+    * Callback fired when event is resized
+    *
+    * ```js
+    * ({originalEvent: event, startDate: date, endDate: date})
+    */
    onResizing: PropTypes.func,
+   /**
+    * Callback fired on mouseup event
+    *
+    * ```js
+    * ({originalEvent: event})
+    */
    onResizeEnd: PropTypes.func,
 
    /**
@@ -612,7 +622,6 @@ class Calendar extends React.Component {
          getDrilldownView={this.getDrilldownView}
          onNavigate={this.handleNavigate}
          onDrillDown={this.handleDrillDown}
-         onResizeEvent={this.handleResizeEvent}
          onSelectEvent={this.handleSelectEvent}
          onSelectSlot={this.handleSelectSlot}
          onShowMore={this._showMore}
@@ -633,10 +642,6 @@ class Calendar extends React.Component {
  handleViewChange = (view) => {
    if (view !== this.props.view && isValidView(view, this.props))
      this.props.onView(view)
- };
-
- handleResizeEvent = (...args) => {
-    notify(this.props.onResizeEvent, args)
  };
 
  handleSelectEvent = (...args) => {

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -4,6 +4,7 @@ import { findDOMNode } from 'react-dom';
 import cn from 'classnames';
 
 import Selection, { getBoundsForNode, isEvent } from './Selection';
+import Resizer from './Resizer';
 import dates from './utils/dates';
 import { isSelected } from './utils/selection';
 import localizer from './localizer'
@@ -42,6 +43,10 @@ class DaySlot extends React.Component {
     selectRangeFormat: dateFormat,
     eventTimeRangeFormat: dateFormat,
     culture: PropTypes.string,
+
+    resizable: PropTypes.oneOf([true, false]),
+    onResizing: PropTypes.func,
+    onResizeEvent: PropTypes.func.isRequired,
 
     selected: PropTypes.object,
     selectable: PropTypes.oneOf([true, false, 'ignoreEvents']),
@@ -182,6 +187,16 @@ class DaySlot extends React.Component {
               { EventComponent
                 ? <EventComponent event={event} title={title}/>
                 : title
+              }
+            </div>
+            <div className='rbc-event-footer'>
+              {
+                this.props.resizable
+                ? <Resizer
+                  {...this.props}
+                  event={event}
+                  boundingNode={this} />
+                : ''
               }
             </div>
           </div>

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -45,8 +45,9 @@ class DaySlot extends React.Component {
     culture: PropTypes.string,
 
     resizable: PropTypes.oneOf([true, false]),
+    onResizingInit: PropTypes.func,
     onResizing: PropTypes.func,
-    onResizeEvent: PropTypes.func.isRequired,
+    onResizingEnd: PropTypes.func,
 
     selected: PropTypes.object,
     selectable: PropTypes.oneOf([true, false, 'ignoreEvents']),

--- a/src/Month.js
+++ b/src/Month.js
@@ -48,6 +48,9 @@ let propTypes = {
   startAccessor: accessor.isRequired,
   endAccessor: accessor.isRequired,
 
+  resizable: PropTypes.oneOf([true, false]),
+  onResizeEvent: PropTypes.func.isRequired,
+
   selected: PropTypes.object,
   selectable: PropTypes.oneOf([true, false, 'ignoreEvents']),
 

--- a/src/Month.js
+++ b/src/Month.js
@@ -49,7 +49,9 @@ let propTypes = {
   endAccessor: accessor.isRequired,
 
   resizable: PropTypes.oneOf([true, false]),
-  onResizeEvent: PropTypes.func.isRequired,
+  onResizingInit: PropTypes.func,
+  onResizing: PropTypes.func,
+  onResizingEnd: PropTypes.func,
 
   selected: PropTypes.object,
   selectable: PropTypes.oneOf([true, false, 'ignoreEvents']),

--- a/src/Resizer.js
+++ b/src/Resizer.js
@@ -65,9 +65,9 @@ class Resizer extends React.Component {
 
     if(typeof this.props.onResizeInit === 'function'){
       let result = this.props.onResizeInit({
-        eventData:    this.props.event,
-        boundingNode: this.props.boundingNode,
-        mouseData:    this._mouseDownData
+        originalEvent: this.props.event,
+        boundingNode:  this.props.boundingNode,
+        mouseData:     this._mouseDownData
       });
 
       if (result === false)
@@ -93,9 +93,9 @@ class Resizer extends React.Component {
     if(!click){
       if(typeof this.props.onResizeEnd === 'function'){
         this.props.onResizeEnd({
-          eventData:    this.props.event,
-          boundingNode: this.props.boundingNode,
-          mouseData:    this._mouseDownData
+          originalEvent: this.props.event,
+          boundingNode:  this.props.boundingNode,
+          mouseData:     this._mouseDownData
         });
       }
     }

--- a/src/Resizer.js
+++ b/src/Resizer.js
@@ -1,0 +1,205 @@
+import React                from 'react';
+import { findDOMNode }      from 'react-dom';
+import events               from 'dom-helpers/events';
+import { notify }           from './utils/helpers';
+import dates                from './utils/dates';
+import { positionFromDate } from './utils/dayViewLayout';
+
+let addEventListener = (type, handler) => {
+  events.on(document, type, handler)
+  return {
+    remove(){ events.off(document, type, handler) }
+  }
+}
+let snapToSlot = (date, step) => {
+  var roundTo = 1000 * 60 * step;
+  return new Date(Math.floor(date.getTime() / roundTo) * roundTo)
+}
+
+let minToDate = (min, date) => {
+  var dt = new Date(date)
+    , totalMins = dates.diff(dates.startOf(date, 'day'), date, 'minutes');
+
+  dt = dates.hours(dt, 0);
+  dt = dates.minutes(dt, totalMins + min);
+  dt = dates.seconds(dt, 0)
+  return dates.milliseconds(dt, 0)
+}
+
+const clickTolerance = 5;
+
+class Resizer extends React.Component {
+
+  constructor({resizable}){
+    super();
+
+    if(!resizable){
+      return;
+    }
+
+    this._mouseDown = this._mouseDown.bind(this)
+    this._mouseMove = this._mouseMove.bind(this)
+    this._mouseUp   = this._mouseUp.bind(this)
+  }
+
+  componentWillUnmount(){
+    this._onMouseUpListener && this._onMouseUpListener.remove();
+    this._onMouseMoveListener && this._onMouseMoveListener.remove();
+  }
+
+  _mouseDown (e) {
+    e.stopPropagation();
+    e.nativeEvent.stopImmediatePropagation();
+
+    // Right clicks
+    if(e.which === 3 || e.button === 2){
+      return;
+    }
+
+    this._mouseDownData = {
+      x: e.pageX,
+      y: e.pageY,
+      clientX: e.clientX,
+      clientY: e.clientY
+    }
+
+    if(typeof this.props.onResizeInit === 'function'){
+      let result = this.props.onResizeInit({
+        eventData:    this.props.event,
+        boundingNode: this.props.boundingNode,
+        mouseData:    this._mouseDownData
+      });
+
+      if (result === false)
+        return;
+    }
+
+    this._onMouseUpListener   = addEventListener('mouseup',   this._mouseUp)
+    this._onMouseMoveListener = addEventListener('mousemove', this._mouseMove)
+  }
+  _mouseUp(e) {
+
+    this._onMouseUpListener && this._onMouseUpListener.remove();
+    this._onMouseMoveListener && this._onMouseMoveListener.remove();
+
+    if (!this._mouseDownData) return;
+
+    var inRoot = !this.container || contains(this.container(), e.target);
+    var bounds = this._resizeRect;
+    var click = this.isClick(e.pageX, e.pageY);
+
+    this._mouseDownData = null
+
+    if(!click){
+      if(typeof this.props.onResizeEnd === 'function'){
+        this.props.onResizeEnd({
+          eventData:    this.props.event,
+          boundingNode: this.props.boundingNode,
+          mouseData:    this._mouseDownData
+        });
+      }
+    }
+  }
+
+  _mouseMove(e) {
+    var { x, y } = this._mouseDownData;
+    var w = Math.abs(x - e.pageX);
+    var h = Math.abs(y - e.pageY);
+
+    let left = Math.min(e.pageX, x)
+      , top = Math.min(e.pageY, y);
+
+    if (!this.isClick(e.pageX, e.pageY)){
+      let box = {
+        top,
+        left,
+        x: e.pageX,
+        y: e.pageY,
+        right: left + w,
+        bottom: top + h
+      };
+
+      let resizingUpdate = ({ y }) => {
+        let { step, min, max } = this.props;
+        let { top, bottom } = getBoundsForNode(findDOMNode(this.props.boundingNode))
+
+        let mins = this._totalMin;
+
+        let range = Math.abs(top - bottom)
+
+        let current = (y - top) / range;
+
+        current = snapToSlot(minToDate(mins * current, min), step)
+
+        let end = dates.min(max, dates.max(current))
+        // this is what gets passed to the onResizing prop
+        return {
+          originalEvent: this.props.event,
+          startDate:     this.props.event.start,
+          endDate:       end
+        };
+      }
+
+      if(typeof this.props.onResizing === 'function'){
+        let udpate     = resizingUpdate(box);
+
+        this.props.onResizing({
+          ...udpate
+        });
+      }
+    }
+  }
+
+  isClick(pageX, pageY){
+    var { x, y } = this._mouseDownData;
+    return (
+      Math.abs(pageX - x) <= clickTolerance &&
+      Math.abs(pageY - y) <= clickTolerance
+    );
+  }
+
+  render(){
+
+    const {
+      min,
+      max
+    } = this.props
+
+    this._totalMin = dates.diff(min, max, 'minutes')
+
+    return (
+      <span className='rbc-event-risizer' onMouseDown={this._mouseDown}>=</span>
+    );
+  }
+}
+
+
+
+/**
+ * Given a node, get everything needed to calculate its boundaries
+ * @param  {HTMLElement} node
+ * @return {Object}
+ */
+export function getBoundsForNode(node) {
+  if (!node.getBoundingClientRect) return node;
+
+  var rect = node.getBoundingClientRect()
+    , left = rect.left + pageOffset('left')
+    , top = rect.top + pageOffset('top');
+
+  return {
+    top,
+    left,
+    right: (node.offsetWidth || 0) + left,
+    bottom: (node.offsetHeight || 0) + top
+  };
+}
+
+function pageOffset(dir) {
+  if (dir === 'left')
+    return (window.pageXOffset || document.body.scrollLeft || 0)
+  if (dir === 'top')
+    return (window.pageYOffset || document.body.scrollTop || 0)
+}
+
+export default Resizer

--- a/src/Resizer.js
+++ b/src/Resizer.js
@@ -37,6 +37,8 @@ class Resizer extends React.Component {
       return;
     }
 
+    this._lastEndDate = null;
+
     this._mouseDown = this._mouseDown.bind(this)
     this._mouseMove = this._mouseMove.bind(this)
     this._mouseUp   = this._mouseUp.bind(this)
@@ -133,6 +135,13 @@ class Resizer extends React.Component {
         current = snapToSlot(minToDate(mins * current, min), step)
 
         let end = dates.min(max, dates.max(current))
+
+        if(this._lastEndDate && this._lastEndDate.getTime() === end.getTime()){
+          return false;
+        }
+
+        this._lastEndDate = end;
+
         // this is what gets passed to the onResizing prop
         return {
           originalEvent: this.props.event,
@@ -143,6 +152,10 @@ class Resizer extends React.Component {
 
       if(typeof this.props.onResizing === 'function'){
         let udpate     = resizingUpdate(box);
+
+        if(udpate === false){
+          return;
+        }
 
         this.props.onResizing({
           ...udpate

--- a/src/Resizer.js
+++ b/src/Resizer.js
@@ -48,6 +48,7 @@ class Resizer extends React.Component {
   }
 
   _mouseDown (e) {
+    e.preventDefault();
     e.stopPropagation();
     e.nativeEvent.stopImmediatePropagation();
 

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -48,6 +48,8 @@ export default class TimeGrid extends Component {
     startAccessor: accessor.isRequired,
     endAccessor: accessor.isRequired,
 
+    resizable: PropTypes.oneOf([true, false]),
+
     selected: PropTypes.object,
     selectable: PropTypes.oneOf([true, false, 'ignoreEvents']),
 
@@ -329,6 +331,10 @@ export default class TimeGrid extends Component {
   handleHeaderClick(date, view, e){
     e.preventDefault()
     notify(this.props.onDrillDown, [date, view])
+  }
+
+  handleResizeEvent(...args) {
+    notify(this.props.onResizeEvent, args)
   }
 
   handleSelectEvent(...args) {

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -333,10 +333,6 @@ export default class TimeGrid extends Component {
     notify(this.props.onDrillDown, [date, view])
   }
 
-  handleResizeEvent(...args) {
-    notify(this.props.onResizeEvent, args)
-  }
-
   handleSelectEvent(...args) {
     notify(this.props.onSelectEvent, args)
   }

--- a/src/less/time-column.less
+++ b/src/less/time-column.less
@@ -55,6 +55,26 @@
     min-height: 1em;
   }
 
+
+  .rbc-event-footer {
+    text-align: center;
+    width: 100%;
+    word-wrap: break-word;
+    position: absolute;
+    bottom: 0px;
+    left: 0;
+
+    .rbc-event-risizer {
+      color: transparent;
+      padding: 2px 4px;
+
+      &:hover,
+      &:active {
+        color: @event-color;
+      }
+    }
+  }
+
   .rbc-time-slot {
     border-top: 1px solid lighten(@cell-border, 10%);
   }


### PR DESCRIPTION
Adds a `resizable` prop that appends a `=` to the bottom of the DayColumn event wrapper that allows for drag-resizing that updates events similar to DnD

```
<BigCalendar
          resizable
          onResizing={this.moveEvent} // receives: originalEvent, startDate, endDate
          onResizeInit={() => true}
```