### PR TITLE
Add event doubleClick handler

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -123,6 +123,15 @@ class Calendar extends React.Component {
     onSelectEvent: PropTypes.func,
 
     /**
+     * Callback fired when a calendar event is clicked twice.
+     *
+     * ```js
+     * (event: Object, e: SyntheticEvent) => any
+     * ```
+     */
+    onDoubleClickEvent: PropTypes.func,
+
+    /**
      * Callback fired when dragging a selection in the Time views.
      *
      * Returning `false` from the handler will prevent a selection.
@@ -645,6 +654,7 @@ class Calendar extends React.Component {
           onNavigate={this.handleNavigate}
           onDrillDown={this.handleDrillDown}
           onSelectEvent={this.handleSelectEvent}
+          onDoubleClickEvent={this.handleDoubleClickEvent}
           onSelectSlot={this.handleSelectSlot}
           onShowMore={this._showMore}
         />
@@ -673,6 +683,10 @@ class Calendar extends React.Component {
   handleSelectEvent = (...args) => {
     notify(this.props.onSelectEvent, args)
   };
+
+  handleDoubleClickEvent = (...args) => {
+    notify(this.props.onDoubleClickEvent, args)
+  }
 
   handleSelectSlot = (slotInfo) => {
     notify(this.props.onSelectSlot, slotInfo)

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -126,7 +126,7 @@ class Calendar extends React.Component {
      * Callback fired when a calendar event is clicked twice.
      *
      * ```js
-     * (event: Object, e: SyntheticEvent) => any
+     * (event: Object, e: SyntheticEvent) => void
      * ```
      */
     onDoubleClickEvent: PropTypes.func,

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -56,6 +56,7 @@ class DayColumn extends React.Component {
     onSelecting: PropTypes.func,
     onSelectSlot: PropTypes.func.isRequired,
     onSelectEvent: PropTypes.func.isRequired,
+    onDoubleClickEvent: PropTypes.func.isRequired,
 
     className: PropTypes.string,
     dragThroughEvents: PropTypes.bool,
@@ -208,6 +209,7 @@ class DayColumn extends React.Component {
             }}
             title={(typeof label === 'string' ? label + ': ' : '') + title }
             onClick={(e) => this._select(event, e)}
+            onDoubleClick={(e) => this._doubleClick(event, e)}
             className={cn('rbc-event', className, {
               'rbc-selected': _isSelected,
               'rbc-event-continues-earlier': continuesPrior,
@@ -346,6 +348,10 @@ class DayColumn extends React.Component {
 
   _select = (...args) => {
     notify(this.props.onSelectEvent, args)
+  };
+
+  _doubleClick = (...args) => {
+    notify(this.props.onDoubleClickEvent, args)
   };
 }
 

--- a/src/EventCell.js
+++ b/src/EventCell.js
@@ -19,7 +19,8 @@ let propTypes = {
 
   eventComponent: elementType,
   eventWrapperComponent: elementType.isRequired,
-  onSelect: PropTypes.func
+  onSelect: PropTypes.func,
+  onDoubleClick: PropTypes.func
 }
 
 class EventCell extends React.Component {
@@ -33,6 +34,7 @@ class EventCell extends React.Component {
       , slotStart
       , slotEnd
       , onSelect
+      , onDoubleClick
       , eventComponent: Event
       , eventWrapperComponent: EventWrapper
       , ...props } = this.props;
@@ -58,6 +60,7 @@ class EventCell extends React.Component {
             'rbc-event-continues-after': continuesAfter
           })}
           onClick={(e) => onSelect(event, e)}
+          onDoubleClick={(e) => onDoubleClick(event, e)}
         >
           <div className='rbc-event-content' title={title}>
             { Event

--- a/src/EventRowMixin.js
+++ b/src/EventRowMixin.js
@@ -23,7 +23,8 @@ export default {
 
     eventComponent: elementType,
     eventWrapperComponent: elementType.isRequired,
-    onSelect: PropTypes.func
+    onSelect: PropTypes.func,
+    onDoubleClick: PropTypes.func
   },
 
   defaultProps: {
@@ -38,7 +39,8 @@ export default {
       , startAccessor, endAccessor, titleAccessor
       , allDayAccessor, eventComponent
       , eventWrapperComponent
-      , onSelect } = props;
+      , onSelect
+      , onDoubleClick } = props;
 
     return (
       <EventCell
@@ -46,6 +48,7 @@ export default {
         eventWrapperComponent={eventWrapperComponent}
         eventPropGetter={eventPropGetter}
         onSelect={onSelect}
+        onDoubleClick={onDoubleClick}
         selected={isSelected(event, selected)}
         startAccessor={startAccessor}
         endAccessor={endAccessor}

--- a/src/Month.js
+++ b/src/Month.js
@@ -56,6 +56,7 @@ let propTypes = {
   onNavigate: PropTypes.func,
   onSelectSlot: PropTypes.func,
   onSelectEvent: PropTypes.func,
+  onDoubleClickEvent: PropTypes.func,
   onShowMore: PropTypes.func,
   onDrillDown: PropTypes.func,
   getDrilldownView: PropTypes.func.isRequired,
@@ -195,6 +196,7 @@ class MonthView extends React.Component {
         renderForMeasure={needLimitMeasure}
         onShowMore={this.handleShowMore}
         onSelect={this.handleSelectEvent}
+        onDoubleClick={this.handleDoubleClickEvent}
         onSelectSlot={this.handleSelectSlot}
         eventComponent={components.event}
         eventWrapperComponent={components.eventWrapper}
@@ -304,6 +306,11 @@ class MonthView extends React.Component {
   handleSelectEvent = (...args) => {
     this.clearSelection()
     notify(this.props.onSelectEvent, args)
+  }
+
+  handleDoubleClickEvent = (...args) => {
+    this.clearSelection()
+    notify(this.props.onDoubleClickEvent, args)
   }
 
   handleShowMore = (events, date, cell, slot) => {

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -58,6 +58,7 @@ export default class TimeGrid extends Component {
     onSelectEnd: PropTypes.func,
     onSelectStart: PropTypes.func,
     onSelectEvent: PropTypes.func,
+    onDoubleClickEvent: PropTypes.func,
     onDrillDown: PropTypes.func,
     getDrilldownView: PropTypes.func.isRequired,
 
@@ -81,6 +82,7 @@ export default class TimeGrid extends Component {
     super(props)
     this.state = { gutterWidth: undefined, isOverflowing: null };
     this.handleSelectEvent = this.handleSelectEvent.bind(this)
+    this.handleDoubleClickEvent = this.handleDoubleClickEvent.bind(this)
     this.handleHeaderClick = this.handleHeaderClick.bind(this)
   }
 
@@ -277,6 +279,7 @@ export default class TimeGrid extends Component {
             eventPropGetter={this.props.eventPropGetter}
             selected={this.props.selected}
             onSelect={this.handleSelectEvent}
+            onDoubleClick={this.handleDoubleClickEvent}
             longPressThreshold={this.props.longPressThreshold}
           />
         </div>
@@ -335,6 +338,10 @@ export default class TimeGrid extends Component {
 
   handleSelectEvent(...args) {
     notify(this.props.onSelectEvent, args)
+  }
+
+  handleDoubleClickEvent(...args) {
+    notify(this.props.onDoubleClickEvent, args)
   }
 
   handleSelectAlldayEvent(...args) {


### PR DESCRIPTION
This PR is part of #563 issue

New:
* `onDoubleClickEvent` handler
    Callback fired when a calendar event is clicked twice.
    `(event: Object, e: SyntheticEvent) => any`

All changes are similar to `onSelectEvent` handler