### PR TITLE
Add doubleClick handlers on empty slots

### DIFF
--- a/src/BackgroundCells.js
+++ b/src/BackgroundCells.js
@@ -20,6 +20,7 @@ class BackgroundCells extends React.Component {
     longPressThreshold: PropTypes.number,
 
     onSelectSlot: PropTypes.func.isRequired,
+    onDoubleClickSlot: PropTypes.func,
     onSelectEnd: PropTypes.func,
     onSelectStart: PropTypes.func,
 
@@ -56,7 +57,7 @@ class BackgroundCells extends React.Component {
   }
 
   render(){
-    let { range, cellWrapperComponent: Wrapper, date: currentDate } = this.props;
+    let { range, cellWrapperComponent: Wrapper, date: currentDate, onDoubleClickSlot } = this.props;
     let { selecting, startIdx, endIdx } = this.state;
 
     return (
@@ -77,6 +78,7 @@ class BackgroundCells extends React.Component {
                   dates.isToday(date) && 'rbc-today',
                   currentDate && dates.month(currentDate) !== dates.month(date) && 'rbc-off-range-bg',
                 )}
+                onDoubleClick={(e) => onDoubleClickSlot(date, e)}
               />
             </Wrapper>
           )

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -112,7 +112,7 @@ class Calendar extends React.Component {
     onSelectSlot: PropTypes.func,
 
     /**
-     * Callback fired when empty calendar cell was clicked twice.
+     * Callback fired when an empty calendar cell was clicked twice.
      *
      * ```js
      * (date: Date, e: SyntheticEvent) => any
@@ -121,7 +121,7 @@ class Calendar extends React.Component {
     onDoubleClickSlot: PropTypes.func,
 
     /**
-     * Callback fired when empty calendar all-day cell was clicked twice.
+     * Callback fired when an empty calendar all-day cell was clicked twice.
      *
      * ```js
      * (date: Date, e: SyntheticEvent) => any

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -112,6 +112,24 @@ class Calendar extends React.Component {
     onSelectSlot: PropTypes.func,
 
     /**
+     * Callback fired when empty calendar cell was clicked twice.
+     *
+     * ```js
+     * (date: Date, e: SyntheticEvent) => any
+     * ```
+     */
+    onDoubleClickSlot: PropTypes.func,
+
+    /**
+     * Callback fired when empty calendar all-day cell was clicked twice.
+     *
+     * ```js
+     * (date: Date, e: SyntheticEvent) => any
+     * ```
+     */
+    onDoubleClickAllDaySlot: PropTypes.func,
+
+    /**
      * Callback fired when a calendar event is selected.
      *
      * ```js
@@ -646,6 +664,8 @@ class Calendar extends React.Component {
           onDrillDown={this.handleDrillDown}
           onSelectEvent={this.handleSelectEvent}
           onSelectSlot={this.handleSelectSlot}
+          onDoubleClickSlot={this.handleDoubleClickSlot}
+          onDoubleClickAllDaySlot={this.handleDoubleClickAllDaySlot}
           onShowMore={this._showMore}
         />
       </div>
@@ -676,6 +696,14 @@ class Calendar extends React.Component {
 
   handleSelectSlot = (slotInfo) => {
     notify(this.props.onSelectSlot, slotInfo)
+  };
+
+  handleDoubleClickSlot = (slotInfo) => {
+    notify(this.props.onDoubleClickSlot, slotInfo)
+  };
+
+  handleDoubleClickAllDaySlot = (slotInfo) => {
+    notify(this.props.onDoubleClickAllDaySlot, slotInfo)
   };
 
   handleDrillDown = (date, view) => {

--- a/src/DateContentRow.js
+++ b/src/DateContentRow.js
@@ -30,6 +30,7 @@ const propTypes = {
 
   onShowMore: PropTypes.func,
   onSelectSlot: PropTypes.func,
+  onDoubleClickSlot: PropTypes.func,
   onSelectEnd: PropTypes.func,
   onSelectStart: PropTypes.func,
 
@@ -153,6 +154,7 @@ class DateContentRow extends React.Component {
       eventWrapperComponent,
       onSelectStart,
       onSelectEnd,
+      onDoubleClickSlot,
       longPressThreshold,
       ...props
     } = this.props;
@@ -181,6 +183,7 @@ class DateContentRow extends React.Component {
           onSelectStart={onSelectStart}
           onSelectEnd={onSelectEnd}
           onSelectSlot={this.handleSelectSlot}
+          onDoubleClickSlot={onDoubleClickSlot}
           cellWrapperComponent={dateCellWrapper}
           longPressThreshold={longPressThreshold}
         />

--- a/src/Month.js
+++ b/src/Month.js
@@ -55,6 +55,7 @@ let propTypes = {
 
   onNavigate: PropTypes.func,
   onSelectSlot: PropTypes.func,
+  onDoubleClickSlot: PropTypes.func,
   onSelectEvent: PropTypes.func,
   onShowMore: PropTypes.func,
   onDrillDown: PropTypes.func,
@@ -165,6 +166,7 @@ class MonthView extends React.Component {
       now,
       date,
       longPressThreshold,
+      onDoubleClickSlot,
     } = this.props
 
     const { needLimitMeasure, rowLimit } = this.state
@@ -196,6 +198,7 @@ class MonthView extends React.Component {
         onShowMore={this.handleShowMore}
         onSelect={this.handleSelectEvent}
         onSelectSlot={this.handleSelectSlot}
+        onDoubleClickSlot={onDoubleClickSlot}
         eventComponent={components.event}
         eventWrapperComponent={components.eventWrapper}
         dateCellWrapper={components.dateCellWrapper}

--- a/src/TimeColumn.js
+++ b/src/TimeColumn.js
@@ -21,6 +21,7 @@ export default class TimeColumn extends Component {
     className: PropTypes.string,
 
     slotPropGetter: PropTypes.func,
+    onDoubleClickSlot: PropTypes.func,
     dayWrapperComponent: elementType,
   }
   static defaultProps = {
@@ -33,7 +34,7 @@ export default class TimeColumn extends Component {
   }
 
   renderTimeSliceGroup(key, isNow, date) {
-    const { dayWrapperComponent, timeslots, showLabels, step, slotPropGetter, timeGutterFormat, culture } = this.props;
+    const { dayWrapperComponent, timeslots, showLabels, step, slotPropGetter, timeGutterFormat, culture, onDoubleClickSlot } = this.props;
 
     return (
       <TimeSlotGroup
@@ -42,6 +43,7 @@ export default class TimeColumn extends Component {
         value={date}
         step={step}
         slotPropGetter={slotPropGetter}
+        onDoubleClickSlot={onDoubleClickSlot}
         culture={culture}
         timeslots={timeslots}
         showLabels={showLabels}

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -55,6 +55,8 @@ export default class TimeGrid extends Component {
 
     onNavigate: PropTypes.func,
     onSelectSlot: PropTypes.func,
+    onDoubleClickSlot: PropTypes.func,
+    onDoubleClickAllDaySlot: PropTypes.func,
     onSelectEnd: PropTypes.func,
     onSelectStart: PropTypes.func,
     onSelectEvent: PropTypes.func,
@@ -227,7 +229,7 @@ export default class TimeGrid extends Component {
   }
 
   renderHeader(range, events, width) {
-    let { messages, rtl, selectable, components, now } = this.props;
+    let { messages, rtl, selectable, components, now, onDoubleClickAllDaySlot } = this.props;
     let { isOverflowing } = this.state || {};
 
     let style = {};
@@ -267,6 +269,7 @@ export default class TimeGrid extends Component {
             className='rbc-allday-cell'
             selectable={selectable}
             onSelectSlot={this.handleSelectAllDaySlot}
+            onDoubleClickSlot={onDoubleClickAllDaySlot}
             dateCellWrapper={components.dateCellWrapper}
             eventComponent={this.props.components.event}
             eventWrapperComponent={this.props.components.eventWrapper}

--- a/src/TimeSlot.js
+++ b/src/TimeSlot.js
@@ -13,6 +13,7 @@ export default class TimeSlot extends Component {
     content: PropTypes.string,
     culture: PropTypes.string,
     slotPropGetter: PropTypes.func,
+    onDoubleClick: PropTypes.func,
   }
 
   static defaultProps = {
@@ -22,7 +23,7 @@ export default class TimeSlot extends Component {
   }
 
   render() {
-    const { value, slotPropGetter } = this.props;
+    const { value, slotPropGetter, onDoubleClick } = this.props;
     const Wrapper = this.props.dayWrapperComponent;
     const { className, style } = (slotPropGetter && slotPropGetter(value)) || {};
 
@@ -36,6 +37,7 @@ export default class TimeSlot extends Component {
             this.props.showLabel && 'rbc-label',
             this.props.isNow && 'rbc-now',
           )}
+          onDoubleClick={(e) => onDoubleClick(value, e)}
         >
         {this.props.showLabel &&
           <span>{this.props.content}</span>

--- a/src/TimeSlotGroup.js
+++ b/src/TimeSlotGroup.js
@@ -14,6 +14,7 @@ export default class TimeSlotGroup extends Component {
     showLabels: PropTypes.bool,
     isNow: PropTypes.bool,
     slotPropGetter: PropTypes.func,
+    onDoubleClickSlot: PropTypes.func,
     timeGutterFormat: dateFormat,
     culture: PropTypes.string
   }
@@ -25,11 +26,12 @@ export default class TimeSlotGroup extends Component {
   }
 
   renderSlice(slotNumber, content, value) {
-    const { dayWrapperComponent, showLabels, isNow, culture, slotPropGetter } = this.props;
+    const { dayWrapperComponent, showLabels, isNow, culture, slotPropGetter, onDoubleClickSlot } = this.props;
     return (
       <TimeSlot
         key={slotNumber}
         slotPropGetter={slotPropGetter}
+        onDoubleClick={onDoubleClickSlot}
         dayWrapperComponent={dayWrapperComponent}
         showLabel={showLabels && !slotNumber}
         content={content}

--- a/src/less/event.less
+++ b/src/less/event.less
@@ -2,6 +2,7 @@
 
 .rbc-event {
   cursor: pointer;
+  pointer-events: all;
   padding: @event-padding;
   background-color: @event-bg;
   border-radius: @event-border-radius;

--- a/src/less/month.less
+++ b/src/less/month.less
@@ -28,6 +28,7 @@
   height: auto;
   line-height: normal;
   white-space: nowrap;
+  pointer-events: all;
 }
 
 .rbc-month-view {
@@ -85,6 +86,7 @@
 
   > a {
     &, &:active, &:visited {
+      pointer-events: all;
       color: inherit;
       text-decoration: none;
     }

--- a/src/less/styles.less
+++ b/src/less/styles.less
@@ -68,6 +68,7 @@
   user-select: none;
   -webkit-user-select: none;
   z-index: 4;
+  pointer-events: none;
 }
 
 .rbc-today {


### PR DESCRIPTION
This PR is a part of #563 issue

New: 
* `onDoubleClickSlot` handler
    Callback fired when empty calendar cell was clicked twice.
     `(date: Date, e: SyntheticEvent) => any`
* `onDoubleClickAllDaySlot` handler
     Callback fired when empty calendar all-day cell was clicked twice.
     `(date: Date, e: SyntheticEvent) => any`

Changes are similar to `onSelectSlot` handler