### PR TITLE
Add doubleClick support to slot selection

### DIFF
--- a/examples/demos/selectable.js
+++ b/examples/demos/selectable.js
@@ -19,7 +19,8 @@ let Selectable = React.createClass({
           onSelectEvent={event => alert(event.title)}
           onSelectSlot={(slotInfo) => alert(
             `selected slot: \n\nstart ${slotInfo.start.toLocaleString()} ` +
-            `\nend: ${slotInfo.end.toLocaleString()}`
+            `\nend: ${slotInfo.end.toLocaleString()}` +
+            `\naction: ${slotInfo.action}`
           )}
         />
       </div>

--- a/src/BackgroundCells.js
+++ b/src/BackgroundCells.js
@@ -91,6 +91,27 @@ class BackgroundCells extends React.Component {
       longPressThreshold: this.props.longPressThreshold,
     })
 
+    let selectorClicksHandler = (point, actionType) => {
+      if (!isEvent(findDOMNode(this), point)) {
+        let rowBox = getBoundsForNode(node)
+        let { range, rtl } = this.props;
+
+        if (pointInBox(rowBox, point)) {
+          let width = slotWidth(getBoundsForNode(node),  range.length);
+          let currentCell = getCellAtX(rowBox, point.x, width, rtl, range.length);
+
+          this._selectSlot({
+            startIdx: currentCell,
+            endIdx: currentCell,
+            action: actionType,
+          })
+        }
+      }
+
+      this._initial = {}
+      this.setState({ selecting: false })
+    };
+
     selector.on('selecting', box => {
       let { range, rtl } = this.props;
 
@@ -125,26 +146,10 @@ class BackgroundCells extends React.Component {
     })
 
     selector
-      .on('click', point => {
-        if (!isEvent(findDOMNode(this), point)) {
-          let rowBox = getBoundsForNode(node)
-          let { range, rtl } = this.props;
+      .on('click', point => selectorClicksHandler(point, 'click'))
 
-          if (pointInBox(rowBox, point)) {
-            let width = slotWidth(getBoundsForNode(node),  range.length);
-            let currentCell = getCellAtX(rowBox, point.x, width, rtl, range.length);
-
-            this._selectSlot({
-              startIdx: currentCell,
-              endIdx: currentCell,
-              action: 'click',
-            })
-          }
-        }
-
-        this._initial = {}
-        this.setState({ selecting: false })
-      })
+    selector
+      .on('doubleClick', point => selectorClicksHandler(point, 'doubleClick'))
 
     selector
       .on('select', () => {

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -104,7 +104,7 @@ class Calendar extends React.Component {
      *     start: Date,
      *     end: Date,
      *     slots: Array<Date>,
-     *     action: "select" | "click"
+     *     action: "select" | "click" | "doubleClick"
      *   }
      * ) => any
      * ```

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -295,6 +295,13 @@ class DayColumn extends React.Component {
       }
     }
 
+    let selectorClicksHandler = (box, actionType) => {
+      if (!isEvent(findDOMNode(this), box))
+        this._selectSlot({ ...selectionState(box), action: actionType })
+
+      this.setState({ selecting: false })
+    }
+
     selector.on('selecting', maybeSelect)
     selector.on('selectStart', maybeSelect)
 
@@ -305,12 +312,10 @@ class DayColumn extends React.Component {
     })
 
     selector
-      .on('click', (box) => {
-        if (!isEvent(findDOMNode(this), box))
-          this._selectSlot({ ...selectionState(box), action: 'click' })
+      .on('click', box => selectorClicksHandler(box, 'click'))
 
-        this.setState({ selecting: false })
-      })
+    selector
+      .on('doubleClick', (box) => selectorClicksHandler(box, 'doubleClick'))
 
     selector
       .on('select', () => {

--- a/src/Selection.js
+++ b/src/Selection.js
@@ -257,16 +257,9 @@ class Selection {
     const { pageX, pageY, clientX, clientY } = getEventCoordinates(e);
     const now = new Date().getTime();
 
-    if (
-        this._lastClickData &&
-        !this._lastClickData.isDblClick &&
-        now - this._lastClickData.timestamp < clickInterval
-    ) {
+    if (this._lastClickData && now - this._lastClickData.timestamp < clickInterval) {
       // Double click event
-      this._lastClickData = {
-        timestamp: now,
-        isDblClick: true,
-      };
+      this._lastClickData = null;
       return this.emit('doubleClick', {
         x: pageX,
         y: pageY,
@@ -275,6 +268,7 @@ class Selection {
       })
     }
 
+    // Click event
     this._lastClickData = {
       timestamp: now,
     };

--- a/src/Selection.js
+++ b/src/Selection.js
@@ -34,7 +34,7 @@ function getEventCoordinates(e) {
 }
 
 const clickTolerance = 5;
-const clickInterval = 200;
+const clickInterval = 250;
 
 class Selection {
 
@@ -256,13 +256,13 @@ class Selection {
   _handleClickEvent(e) {
     const { pageX, pageY, clientX, clientY } = getEventCoordinates(e);
     const now = new Date().getTime();
+
     if (this._lastClickData && now - this._lastClickData.timestamp < clickInterval) {
       // Double click event
       this._lastClickData = {
         timestamp: now,
         isDblClick: true,
       };
-      clearTimeout(this._clickTimer); // Don't emit first click of doubleClick event
       return this.emit('doubleClick', {
         x: pageX,
         y: pageY,
@@ -270,20 +270,16 @@ class Selection {
         clientY: clientY,
       })
     }
+
     this._lastClickData = {
       timestamp: now,
     };
-    this._clickTimer = setTimeout(() => {
-      this._lastClickData = {
-        timestamp: now,
-      }
-      return this.emit('click', {
-        x: pageX,
-        y: pageY,
-        clientX: clientX,
-        clientY: clientY,
-      })
-    }, clickInterval);
+    return this.emit('click', {
+      x: pageX,
+      y: pageY,
+      clientX: clientX,
+      clientY: clientY,
+    });
   }
 
   _handleMoveEvent(e) {

--- a/src/Selection.js
+++ b/src/Selection.js
@@ -257,7 +257,11 @@ class Selection {
     const { pageX, pageY, clientX, clientY } = getEventCoordinates(e);
     const now = new Date().getTime();
 
-    if (this._lastClickData && now - this._lastClickData.timestamp < clickInterval) {
+    if (
+        this._lastClickData &&
+        !this._lastClickData.isDblClick &&
+        now - this._lastClickData.timestamp < clickInterval
+    ) {
       // Double click event
       this._lastClickData = {
         timestamp: now,

--- a/src/Selection.js
+++ b/src/Selection.js
@@ -34,6 +34,7 @@ function getEventCoordinates(e) {
 }
 
 const clickTolerance = 5;
+const clickInterval = 200;
 
 class Selection {
 
@@ -224,7 +225,7 @@ class Selection {
   }
 
   _handleTerminatingEvent(e) {
-    const { pageX, pageY, clientX, clientY } = getEventCoordinates(e);
+    const { pageX, pageY } = getEventCoordinates(e);
 
     this.selecting = false;
 
@@ -243,17 +244,46 @@ class Selection {
       return this.emit('reset')
     }
 
-    if(click && inRoot)
+    if(click && inRoot) {
+      return this._handleClickEvent(e);
+    }
+
+    // User drag-clicked in the Selectable area
+    if(!click)
+      return this.emit('select', bounds)
+  }
+
+  _handleClickEvent(e) {
+    const { pageX, pageY, clientX, clientY } = getEventCoordinates(e);
+    const now = new Date().getTime();
+    if (this._lastClickData && now - this._lastClickData.timestamp < clickInterval) {
+      // Double click event
+      this._lastClickData = {
+        timestamp: now,
+        isDblClick: true,
+      };
+      clearTimeout(this._clickTimer); // Don't emit first click of doubleClick event
+      return this.emit('doubleClick', {
+        x: pageX,
+        y: pageY,
+        clientX: clientX,
+        clientY: clientY,
+      })
+    }
+    this._lastClickData = {
+      timestamp: now,
+    };
+    this._clickTimer = setTimeout(() => {
+      this._lastClickData = {
+        timestamp: now,
+      }
       return this.emit('click', {
         x: pageX,
         y: pageY,
         clientX: clientX,
         clientY: clientY,
       })
-
-    // User drag-clicked in the Selectable area
-    if(!click)
-      return this.emit('select', bounds)
+    }, clickInterval);
   }
 
   _handleMoveEvent(e) {


### PR DESCRIPTION
This PR is a part of #563 issue

### Purpose:
Selection object already has support for slot selection with `action: 'click'` property passed to `onSelectSlot`. We have to add support for double click interaction, with `action: 'doubleClick'` property passed.

### Problem:
Now Selection object emits `click` event on every click, so if you click twice, it will emit 2 `click` events with a small delay.

### Solution:
To emit `doubleClick` event inside `Selection` object, we have to check, wether first click is just a single click (then we emit `click` event), or it's the first click of double click (then we should mute it):
1. User makes the first click. Don't emit `click` event yet. Create a timeout for 200ms (usual max delay between 2 clicks of double click). Remeber timestamp of the first click.
2. User makes the second click. Check current time and the timestamp of first click. If it's less than 200ms, then emit `doubleClick` event and clear created timeout, else emit `click` event.
3. If user haven't made the second click, emit `click` event inside created timeout

### Disadvantage: 
`onSelectSlot` handler for `click` events can be called only after 200ms after user click. I don't think we can make this delay less, because normal delay between 2 clicks of `doubleClick` event can be up to 170ms.