### PR TITLE
Give to the dateCellWrapper a base className

### DIFF
--- a/src/BackgroundCells.js
+++ b/src/BackgroundCells.js
@@ -62,22 +62,25 @@ class BackgroundCells extends React.Component {
     return (
       <div className='rbc-row-bg'>
         {range.map((date, index) => {
-          let selected =  selecting && index >= startIdx && index <= endIdx;
+          let selected =  selecting && index >= startIdx && index <= endIdx,
+              classNames = cn(
+                  'rbc-day-bg',
+                  selected && 'rbc-selected-cell',
+                  dates.isToday(date) && 'rbc-today',
+                  currentDate && dates.month(currentDate) !== dates.month(date) && 'rbc-off-range-bg',
+              );
+
           return (
             <Wrapper
               key={index}
               value={date}
               range={range}
+              baseClasses={classNames}
             >
               <div
                 style={segStyle(1, range.length)}
-                className={cn(
-                  'rbc-day-bg',
-                  selected && 'rbc-selected-cell',
-                  dates.isToday(date) && 'rbc-today',
-                  currentDate && dates.month(currentDate) !== dates.month(date) && 'rbc-off-range-bg',
-                )}
-              />
+                className={classNames}
+              ></div>
             </Wrapper>
           )
         })}


### PR DESCRIPTION
I start from my needs: I want to add some classes in the cell of the month view.

**Specific**
When I override the default dateCellWrapper and I want to add some classes classes, now I have to return `this.props.children` otherwise I lose the base classes names(rbc-off-range-bg, rbc-selected-cell)

**Solution proposed**
I put the result of the 'cn' function in a variable and I pass it as prop in the `Wrapper`
