### PR TITLE
Added day param to the cell wrapper

### DIFF
--- a/src/BackgroundCells.js
+++ b/src/BackgroundCells.js
@@ -56,18 +56,28 @@ class BackgroundCells extends React.Component {
   }
 
   render(){
-    let { range, cellWrapperComponent: Wrapper, date: currentDate } = this.props;
+    let { range, cellWrapperComponent: Wrapper, date: currentDate, specialDays } = this.props;
     let { selecting, startIdx, endIdx } = this.state;
 
     return (
       <div className='rbc-row-bg'>
         {range.map((date, index) => {
-          let selected =  selecting && index >= startIdx && index <= endIdx;
+          let selected =  selecting && index >= startIdx && index <= endIdx,
+              day = specialDays.reduce((acc, day) => {
+                if( dates.sameDay(date, day.day) )
+                  acc = day;
+
+                return acc;
+              }, null);
+
+          console.log(this.props);
+
           return (
             <Wrapper
               key={index}
               value={date}
               range={range}
+              day={day}
             >
               <div
                 style={segStyle(1, range.length)}

--- a/src/BackgroundCells.js
+++ b/src/BackgroundCells.js
@@ -18,6 +18,7 @@ class BackgroundCells extends React.Component {
     container: PropTypes.func,
     selectable: PropTypes.oneOf([true, false, 'ignoreEvents']),
     longPressThreshold: PropTypes.number,
+    specialDays: PropTypes.array,
 
     onSelectSlot: PropTypes.func.isRequired,
     onSelectEnd: PropTypes.func,

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -82,6 +82,11 @@ class Calendar extends React.Component {
     events: PropTypes.arrayOf(PropTypes.object),
 
     /**
+     * An array of day objects for customizing cells
+     */
+    specialDays: PropTypes.arrayOf(PropTypes.object),
+
+    /**
      * Callback fired when the `date` value changes.
      *
      * @controllable date
@@ -544,6 +549,7 @@ class Calendar extends React.Component {
     views: [views.MONTH, views.WEEK, views.DAY, views.AGENDA],
     date: now,
     step: 30,
+    specialDays: [],
 
     drilldownView: views.DAY,
 
@@ -597,6 +603,7 @@ class Calendar extends React.Component {
       , formats = {}
       , messages = {}
       , style
+      , specialDays
       , className
       , elementProps
       , date: current
@@ -648,6 +655,7 @@ class Calendar extends React.Component {
           culture={culture}
           formats={undefined}
           events={events}
+          specialDays={specialDays}
           date={current}
           components={viewComponents}
           getDrilldownView={this.getDrilldownView}

--- a/src/DateContentRow.js
+++ b/src/DateContentRow.js
@@ -18,6 +18,7 @@ const propTypes = {
   date: PropTypes.instanceOf(Date),
   events: PropTypes.array.isRequired,
   range: PropTypes.array.isRequired,
+  specialDays: PropTypes.array,
 
   rtl: PropTypes.bool,
   renderForMeasure: PropTypes.bool,
@@ -154,6 +155,7 @@ class DateContentRow extends React.Component {
       onSelectStart,
       onSelectEnd,
       longPressThreshold,
+      specialDays,
       ...props
     } = this.props;
 
@@ -183,6 +185,7 @@ class DateContentRow extends React.Component {
           onSelectSlot={this.handleSelectSlot}
           cellWrapperComponent={dateCellWrapper}
           longPressThreshold={longPressThreshold}
+          specialDays={specialDays}
         />
 
         <div className='rbc-row-content'>

--- a/src/Month.js
+++ b/src/Month.js
@@ -27,6 +27,7 @@ let eventsForWeek = (evts, start, end, props) =>
 
 let propTypes = {
   events: PropTypes.array.isRequired,
+  specialDays: PropTypes.array,
   date: PropTypes.instanceOf(Date),
 
   min: PropTypes.instanceOf(Date),
@@ -166,6 +167,7 @@ class MonthView extends React.Component {
       now,
       date,
       longPressThreshold,
+      specialDays
     } = this.props
 
     const { needLimitMeasure, rowLimit } = this.state
@@ -202,6 +204,7 @@ class MonthView extends React.Component {
         eventWrapperComponent={components.eventWrapper}
         dateCellWrapper={components.dateCellWrapper}
         longPressThreshold={longPressThreshold}
+        specialDays={specialDays}
       />
     )
   }

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -26,6 +26,7 @@ export default class TimeGrid extends Component {
 
   static propTypes = {
     events: PropTypes.array.isRequired,
+    specialDays: PropTypes.array,
 
     step: PropTypes.number,
     range: PropTypes.arrayOf(
@@ -146,7 +147,7 @@ export default class TimeGrid extends Component {
       , startAccessor
       , endAccessor
       , allDayAccessor
-      , showMultiDayTimes} = this.props;
+      , showMultiDayTimes } = this.props;
 
     width = width || this.state.gutterWidth;
 
@@ -229,7 +230,7 @@ export default class TimeGrid extends Component {
   }
 
   renderHeader(range, events, width) {
-    let { messages, rtl, selectable, components, now } = this.props;
+    let { messages, rtl, selectable, components, now, specialDays } = this.props;
     let { isOverflowing } = this.state || {};
 
     let style = {};
@@ -281,6 +282,7 @@ export default class TimeGrid extends Component {
             onSelect={this.handleSelectEvent}
             onDoubleClick={this.handleDoubleClickEvent}
             longPressThreshold={this.props.longPressThreshold}
+            specialDays={specialDays}
           />
         </div>
       </div>

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -82,6 +82,12 @@ let dates = {
     return dates.eq(dateA, dateB, 'month')
   },
 
+  sameDay(dateA, dateB){
+    return dateA.getFullYear() === dateB.getFullYear() &&
+      dateA.getMonth() === dateB.getMonth() &&
+      dateA.getDate() === dateB.getDate();
+  },
+
   isToday(date) {
     return dates.eq(date, dates.today(), 'day')
   },


### PR DESCRIPTION
Hi,

my need is to customize the cell wrapper from a given array of object(array of specialDays), but when I override the cell Wrapper I can't retrieve the exact item I need from this array.

In this PR i create a new prop `specialDays` that work similar to the `event` prop. 

```javascript
const specialDays = [
        {
          'day': new Date(2015, 3, 0),
          'classNameToAdd': "try"
        },
        {
          'day': new Date(2017, 3, 0),
        }
      ];

<BigCalendar
        events={events}
        specialDays={specialDays}
      />
```
_The required property in the specialDays item is `day`._

The prop `specialDays` is passed to the custom cellWrapper as prop so i can customize the cell in according to the`specialDays` array.

```javascript
const CustomMonthCell = React.createClass({
  render() {
      let { range, day } = this.props;


      const baseClasses = this.props.children.props.className,
        defaultStyle = segStyle(1, range.length);

      if( day ){
        defaultStyle.background = 'red';
      }

      return (
          <div style={defaultStyle}
               className={baseClasses}>
              {this.props.children}
          </div>
      )
  }
});
```

## Result
<img width="1129" alt="schermata 2017-10-19 alle 15 12 35" src="https://user-images.githubusercontent.com/3227441/31773086-e9ebddcc-b4e1-11e7-9303-2a7582ef4b1e.png">

