### PR TITLE
fix agendaHeaderFormat in Calendar

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -444,7 +444,7 @@ class Calendar extends React.Component {
       /**
        * Toolbar header format for the Agenda view, e.g. "4/1/2015 — 5/1/2015"
        */
-      agendaHeaderFormat: dateFormat,
+      agendaHeaderFormat: dateRangeFormat,
 
       /**
        * A time range format for selecting time slots, e.g "8:00am — 2:00pm"


### PR DESCRIPTION
The documentation is showing the wrong information for `agendaHeaderFormat` -- it is `dateRangeFormat` not `dateFormat`. I tracked it down to it being set wrong in `src/Calendar.js`.