### PR TITLE
onSelectSlot callback is called instead of onSelectEvent (sometimes) …

### DIFF
--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -122,14 +122,6 @@ class DayColumn extends React.Component {
         step={step}
       >
         {this.renderEvents()}
-
-        {selecting &&
-          <div className='rbc-slot-selection' style={style}>
-              <span>
-              { localizer.format(selectDates, selectRangeFormat, culture) }
-              </span>
-          </div>
-        }
       </TimeColumn>
     );
   }

--- a/src/less/time-grid.less
+++ b/src/less/time-grid.less
@@ -1,16 +1,6 @@
 @import './variables.less';
 @import './time-column.less';
 
-.rbc-slot-selection {
-  z-index: 10;
-  position: absolute;
-  cursor: default;
-  background-color: @time-selection-bg-color;
-  color: @time-selection-color;
-  font-size: 75%;
-  padding: 3px;
-}
-
 .rbc-time-view {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
…#614

Sometimes, clicking on an event will execute the onSelectSlot callback (instead of onSelectEvent)
This is caused by the document.elementFromPoint (in isEvent function of Selection.js) which will return the span contained in the rbc-slot-selection div...
Removing the following code from DayColumn.js fixed that issue but I'm not sure 100% that it's the better way to do it. rbc-slot-selection does not seems to be used

&& _react2.default.createElement(
'div',
{ className: 'rbc-slot-selection', style: style },
_react2.default.createElement(
'span',
null,
_localizer2.default.format(selectDates, selectRangeFormat, culture)
)
)