### PR TITLE
fix border alignment issues

### DIFF
--- a/src/less/time-grid.less
+++ b/src/less/time-grid.less
@@ -24,6 +24,7 @@
   }
 
   .rbc-allday-cell {
+    box-sizing: content-box;
     width: 100%;
     position: relative;
   }
@@ -34,6 +35,7 @@
   }
 
   .rbc-row {
+    box-sizing: border-box;
     min-height: 20px;
   }
 }


### PR DESCRIPTION
There's currently a minor alignment issue with the borders in the week view (https://github.com/intljusticemission/react-big-calendar/issues/631). This fixes it for me (tested in latest chrome, safari and ff on mac), and I haven't seen any other problems with it. 

**Before:**
<img width="888" alt="screen shot 2018-01-04 at 02 27 33" src="https://user-images.githubusercontent.com/3599069/34546941-afdad564-f0f7-11e7-9a04-775d24157922.png">

**After:**
<img width="886" alt="screen shot 2018-01-04 at 02 28 00" src="https://user-images.githubusercontent.com/3599069/34546942-b26b5f1a-f0f7-11e7-9f1e-7d661a176371.png">
