### PR TITLE
Added ability to hide gutter and time indicator

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -397,6 +397,17 @@ class Calendar extends React.Component {
     scrollToTime: PropTypes.instanceOf(Date),
 
     /**
+     * Hides the gutter on the left that shows the time intervals on views where the gutter is shown.
+     */
+    hideGutter: PropTypes.bool,
+
+    /**
+     * Hides the time indicator line on views where it is shown.
+     * The time indicator will always be hidden if `hideGutter` is true
+     */
+    hideTimeIndicator: PropTypes.bool,
+
+    /**
      * Specify a specific culture code for the Calendar.
      *
      * **Note: it's generally better to handle this globally via your i18n library.**
@@ -582,6 +593,8 @@ class Calendar extends React.Component {
     resourceIdAccessor: 'resourceId',
 
     longPressThreshold: 250,
+    hideGutter: false,
+    hideTimeIndicator: false,
   }
 
   getViews = () => {

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -53,6 +53,9 @@ export default class TimeGrid extends Component {
     selectable: PropTypes.oneOf([true, false, 'ignoreEvents']),
     longPressThreshold: PropTypes.number,
 
+    hideGutter: PropTypes.bool,
+    hideTimeIndicator: PropTypes.bool,
+
     onNavigate: PropTypes.func,
     onSelectSlot: PropTypes.func,
     onSelectEnd: PropTypes.func,
@@ -148,6 +151,8 @@ export default class TimeGrid extends Component {
       resources,
       allDayAccessor,
       showMultiDayTimes,
+      hideGutter,
+      hideTimeIndicator,
     } = this.props
 
     width = width || this.state.gutterWidth
@@ -188,15 +193,17 @@ export default class TimeGrid extends Component {
         {this.renderHeader(range, allDayEvents, width, resources)}
 
         <div ref="content" className="rbc-time-content">
-          <div ref="timeIndicator" className="rbc-current-time-indicator" />
+          {!hideTimeIndicator && <div ref="timeIndicator" className="rbc-current-time-indicator" />}
 
-          <TimeColumn
-            {...this.props}
-            showLabels
-            style={{ width }}
-            ref={gutterRef}
-            className="rbc-time-gutter"
-          />
+          {!hideGutter && (
+            <TimeColumn
+              {...this.props}
+              showLabels
+              style={{ width }}
+              ref={gutterRef}
+              className="rbc-time-gutter"
+            />
+          )}
           {eventsRendered}
         </div>
       </div>
@@ -236,7 +243,7 @@ export default class TimeGrid extends Component {
   }
 
   renderHeader(range, events, width, resources) {
-    let { messages, rtl, selectable, components, now } = this.props
+    let { messages, rtl, selectable, components, now, hideGutter } = this.props
     let { isOverflowing } = this.state || {}
 
     let style = {}
@@ -253,23 +260,26 @@ export default class TimeGrid extends Component {
         style={style}
       >
         <div className="rbc-row">
-          <div className="rbc-label rbc-header-gutter" style={{ width }} />
+          {!hideGutter && <div className="rbc-label rbc-header-gutter" style={{ width }} />}
           {this.renderHeaderCells(range)}
         </div>
         {resources && (
           <div className="rbc-row rbc-row-resource">
-            <div className="rbc-label rbc-header-gutter" style={{ width }} />
+            {!hideGutter && <div className="rbc-label rbc-header-gutter" style={{ width }} />}
             {headerRendered}
           </div>
         )}
         <div className="rbc-row">
-          <div
-            ref={ref => (this._gutters[0] = ref)}
-            className="rbc-label rbc-header-gutter"
-            style={{ width }}
-          >
-            {message(messages).allDay}
-          </div>
+          {message &&
+            !hideGutter && (
+              <div
+                ref={ref => (this._gutters[0] = ref)}
+                className="rbc-label rbc-header-gutter"
+                style={{ width }}
+              >
+                {message(messages).allDay}
+              </div>
+            )}
           <DateContentRow
             now={now}
             minRows={2}
@@ -421,6 +431,7 @@ export default class TimeGrid extends Component {
   }
 
   positionTimeIndicator() {
+    if (this.props.hideTimeIndicator) return
     const { rtl, min, max } = this.props
     const now = new Date()
 


### PR DESCRIPTION
Added the ability to pass in two additional optional props  and
hideGutter=true will hide the gutter in an view where there is a time sidebar (except agenda view)
hideTimeIndicator=true will hide the time indicator in views where this is shown

If the gutter is hidden, then the time indicator will also be hidden

Impacted Views:
**week**, **work_week**, **day**

![image](https://user-images.githubusercontent.com/5461649/34641159-f855fbcc-f2bc-11e7-8004-984ee7d4bc57.png)

![image](https://user-images.githubusercontent.com/5461649/34641164-13af50da-f2bd-11e7-98ad-7ca0dac21bc3.png)
