### PR TITLE
Current timeslot indicator does not update if page is left open #636

### DIFF
--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -90,6 +90,7 @@ export default class TimeGrid extends Component {
     this.handleSelectEvent = this.handleSelectEvent.bind(this)
     this.handleDoubleClickEvent = this.handleDoubleClickEvent.bind(this)
     this.handleHeaderClick = this.handleHeaderClick.bind(this)
+    this.updateNow = this.updateNow.bind(this)
   }
 
   componentWillMount() {
@@ -117,13 +118,7 @@ export default class TimeGrid extends Component {
     if (this.props.width == null && !this.state.gutterWidth) {
       this.measureGutter()
     }
-    if (
-      !this.props.now &&
-      dates.diff(new Date(), this.state.date, 'seconds') > 60
-    ) {
-      // Update now() at most every 60 seconds if changes occur
-      this.setState({ now: new Date() })
-    }
+
     this.applyScroll()
     this.positionTimeIndicator()
     //this.checkOverflow()
@@ -138,8 +133,12 @@ export default class TimeGrid extends Component {
     ) {
       this.calculateScroll()
     }
-    if (nextProps.now !== this.state.now) {
-      this.setState({ now: nextProps.now || new Date() })
+    // If now changed, then use nextProps.now unless null|undefined
+    if (nextProps.now !== this.props.now) {
+      this.updateNow(nextProps.now || new Date())
+    } else {
+      // update now if prop does not exist
+      this.updateNow(this.props.now || new Date())
     }
   }
 
@@ -151,6 +150,10 @@ export default class TimeGrid extends Component {
       end: slots[slots.length - 1],
       action: slotInfo.action,
     })
+  }
+
+  updateNow(now) {
+    this.setState({ now })
   }
 
   render() {
@@ -506,6 +509,7 @@ export default class TimeGrid extends Component {
     // Update the position of the time indicator every minute
     this._timeIndicatorTimeout = window.setTimeout(() => {
       this.positionTimeIndicator()
+      this.updateNow(this.props.now || new Date())
 
       this.triggerTimeIndicatorUpdate()
     }, 60000)


### PR DESCRIPTION
If `now` is not passed to `TimeGrid`, then dynamically update `now` upon component changes
If a caller passes in `now` using props, then no automatic changes will occur to state and the caller must manage updates

resolves #636

cc @sciyoshi

@jquense - I went ahead and implement #636 as my project could benefit from this change.  Please let me know if the changes are satisfactory or if you would like me to change anything.

Thank you!