### PR TITLE
use es6 instead of React.createClass for examples

### DIFF
--- a/examples/Api.js
+++ b/examples/Api.js
@@ -14,7 +14,7 @@ let cleanDocletValue = str =>
     .replace(/^\{/, '')
     .replace(/\}$/, '')
 
-let Api = React.createClass({
+class Api extends React.Component {
   render() {
     let calData = metadata.Calendar
 
@@ -33,7 +33,7 @@ let Api = React.createClass({
         })}
       </div>
     )
-  },
+  }
 
   renderProp(data, name, Heading) {
     let typeInfo = this.renderType(data)
@@ -78,7 +78,7 @@ let Api = React.createClass({
         )}
       </section>
     )
-  },
+  }
 
   renderType(prop) {
     let type = prop.type || {}
@@ -136,12 +136,12 @@ let Api = React.createClass({
       default:
         return name
     }
-  },
+  }
 
   renderEnum(enumType) {
     const enumValues = enumType.value || []
     return <code>{enumValues.join(' | ')}</code>
-  },
+  }
 
   renderControllableNote(prop, propName) {
     let controllable = prop.doclets && prop.doclets.controllable
@@ -170,8 +170,8 @@ let Api = React.createClass({
         </em>
       </div>
     )
-  },
-})
+  }
+}
 
 function getDisplayTypeName(typeName) {
   if (typeName === 'func') {

--- a/examples/App.js
+++ b/examples/App.js
@@ -24,12 +24,8 @@ import Dnd from './demos/dnd'
 let demoRoot =
   'https://github.com/intljusticemission/react-big-calendar/tree/master/examples/demos'
 
-const Example = React.createClass({
-  getInitialState() {
-    return {
-      selected: 'basic',
-    }
-  },
+class Example extends React.Component {
+  state = { selected: 'basic' }
 
   render() {
     let selected = this.state.selected
@@ -133,12 +129,12 @@ const Example = React.createClass({
         </div>
       </div>
     )
-  },
+  }
 
-  select(selected, e) {
+  select = (selected, e) => {
     e.preventDefault()
     this.setState({ selected })
-  },
-})
+  }
+}
 
 render(<Example />, document.getElementById('root'))

--- a/examples/demos/basic.js
+++ b/examples/demos/basic.js
@@ -4,18 +4,14 @@ import events from '../events'
 
 let allViews = Object.keys(BigCalendar.Views).map(k => BigCalendar.Views[k])
 
-let Basic = React.createClass({
-  render() {
-    return (
-      <BigCalendar
-        {...this.props}
-        events={events}
-        views={allViews}
-        step={60}
-        defaultDate={new Date(2015, 3, 1)}
-      />
-    )
-  },
-})
+let Basic = props => (
+  <BigCalendar
+    {...props}
+    events={events}
+    views={allViews}
+    step={60}
+    defaultDate={new Date(2015, 3, 1)}
+  />
+)
 
 export default Basic

--- a/examples/demos/cultures.js
+++ b/examples/demos/cultures.js
@@ -7,10 +7,8 @@ require('globalize/lib/cultures/globalize.culture.es')
 require('globalize/lib/cultures/globalize.culture.fr')
 require('globalize/lib/cultures/globalize.culture.ar-AE')
 
-let Cultures = React.createClass({
-  getInitialState() {
-    return { culture: 'fr' }
-  },
+class Cultures extends React.Component {
+  state = { culture: 'fr' }
 
   render() {
     let cultures = ['en', 'en-GB', 'es', 'fr', 'ar-AE']
@@ -41,7 +39,7 @@ let Cultures = React.createClass({
         />
       </div>
     )
-  },
-})
+  }
+}
 
 export default Cultures

--- a/examples/demos/customHeader.js
+++ b/examples/demos/customHeader.js
@@ -2,40 +2,27 @@ import React from 'react'
 import BigCalendar from 'react-big-calendar'
 import events from '../events'
 
-let MyOtherNestedComponent = React.createClass({
-  render() {
-    return <div>NESTED COMPONENT</div>
-  },
-})
+let MyOtherNestedComponent = () => <div>NESTED COMPONENT</div>
 
-let MyCustomHeader = React.createClass({
-  render() {
-    const { label } = this.props
-    return (
-      <div>
-        CUSTOM HEADER:
-        <div>{label}</div>
-        <MyOtherNestedComponent />
-      </div>
-    )
-  },
-})
+let MyCustomHeader = ({ label }) => (
+  <div>
+    CUSTOM HEADER:
+    <div>{label}</div>
+    <MyOtherNestedComponent />
+  </div>
+)
 
-let CustomHeader = React.createClass({
-  render() {
-    return (
-      <BigCalendar
-        {...this.props}
-        events={events}
-        defaultDate={new Date(2015, 3, 1)}
-        components={{
-          day: { header: MyCustomHeader },
-          week: { header: MyCustomHeader },
-          month: { header: MyCustomHeader },
-        }}
-      />
-    )
-  },
-})
+let CustomHeader = props => (
+  <BigCalendar
+    {...this.props}
+    events={events}
+    defaultDate={new Date(2015, 3, 1)}
+    components={{
+      day: { header: MyCustomHeader },
+      week: { header: MyCustomHeader },
+      month: { header: MyCustomHeader },
+    }}
+  />
+)
 
 export default CustomHeader

--- a/examples/demos/customView.js
+++ b/examples/demos/customView.js
@@ -47,19 +47,15 @@ MyWeek.title = (date, { formats, culture }) => {
   return `My awesome week: ${Date.toLocaleString()}`
 }
 
-let CustomView = React.createClass({
-  render() {
-    return (
-      <div>
-        <BigCalendar
-          events={events}
-          defaultDate={new Date(2015, 3, 1)}
-          views={{ month: true, week: MyWeek }}
-          test="io"
-        />
-      </div>
-    )
-  },
-})
+let CustomView = props => (
+  <div>
+    <BigCalendar
+      events={events}
+      defaultDate={new Date(2015, 3, 1)}
+      views={{ month: true, week: MyWeek }}
+      test="io"
+    />
+  </div>
+)
 
 export default CustomView

--- a/examples/demos/popup.js
+++ b/examples/demos/popup.js
@@ -1,18 +1,15 @@
 import React from 'react'
 import BigCalendar from 'react-big-calendar'
 import events from '../events'
-let Popup = React.createClass({
-  render() {
-    return (
-      <div {...this.props}>
-        <h3 className="callout">
-          Click the "+x more" link on any calendar day that cannot fit all the
-          days events to see an inline popup of all the events.
-        </h3>
-        <BigCalendar popup events={events} defaultDate={new Date(2015, 3, 1)} />
-      </div>
-    )
-  },
-})
+
+let Popup = props => (
+  <div {...props}>
+    <h3 className="callout">
+      Click the "+x more" link on any calendar day that cannot fit all the days
+      events to see an inline popup of all the events.
+    </h3>
+    <BigCalendar popup events={events} defaultDate={new Date(2015, 3, 1)} />
+  </div>
+)
 
 export default Popup

--- a/examples/demos/rendering.js
+++ b/examples/demos/rendering.js
@@ -39,26 +39,22 @@ const customSlotPropGetter = date => {
   else return {}
 }
 
-let Rendering = React.createClass({
-  render() {
-    return (
-      <div {...this.props}>
-        <BigCalendar
-          events={events}
-          defaultDate={new Date(2015, 3, 1)}
-          defaultView="agenda"
-          dayPropGetter={customDayPropGetter}
-          slotPropGetter={customSlotPropGetter}
-          components={{
-            event: Event,
-            agenda: {
-              event: EventAgenda,
-            },
-          }}
-        />
-      </div>
-    )
-  },
-})
+let Rendering = props => (
+  <div {...props}>
+    <BigCalendar
+      events={events}
+      defaultDate={new Date(2015, 3, 1)}
+      defaultView="agenda"
+      dayPropGetter={customDayPropGetter}
+      slotPropGetter={customSlotPropGetter}
+      components={{
+        event: Event,
+        agenda: {
+          event: EventAgenda,
+        },
+      }}
+    />
+  </div>
+)
 
 export default Rendering

--- a/examples/demos/selectable.js
+++ b/examples/demos/selectable.js
@@ -2,32 +2,28 @@ import React from 'react'
 import BigCalendar from 'react-big-calendar'
 import events from '../events'
 
-let Selectable = React.createClass({
-  render() {
-    return (
-      <div {...this.props}>
-        <h3 className="callout">
-          Click an event to see more info, or drag the mouse over the calendar
-          to select a date/time range.
-        </h3>
-        <BigCalendar
-          selectable
-          events={events}
-          defaultView="week"
-          scrollToTime={new Date(1970, 1, 1, 6)}
-          defaultDate={new Date(2015, 3, 12)}
-          onSelectEvent={event => alert(event.title)}
-          onSelectSlot={slotInfo =>
-            alert(
-              `selected slot: \n\nstart ${slotInfo.start.toLocaleString()} ` +
-                `\nend: ${slotInfo.end.toLocaleString()}` +
-                `\naction: ${slotInfo.action}`
-            )
-          }
-        />
-      </div>
-    )
-  },
-})
+let Selectable = props => (
+  <div {...props}>
+    <h3 className="callout">
+      Click an event to see more info, or drag the mouse over the calendar to
+      select a date/time range.
+    </h3>
+    <BigCalendar
+      selectable
+      events={events}
+      defaultView="week"
+      scrollToTime={new Date(1970, 1, 1, 6)}
+      defaultDate={new Date(2015, 3, 12)}
+      onSelectEvent={event => alert(event.title)}
+      onSelectSlot={slotInfo =>
+        alert(
+          `selected slot: \n\nstart ${slotInfo.start.toLocaleString()} ` +
+            `\nend: ${slotInfo.end.toLocaleString()}` +
+            `\naction: ${slotInfo.action}`
+        )
+      }
+    />
+  </div>
+)
 
 export default Selectable

--- a/examples/demos/timeslots.js
+++ b/examples/demos/timeslots.js
@@ -2,19 +2,15 @@ import React from 'react'
 import BigCalendar from 'react-big-calendar'
 import events from '../events'
 
-let Timeslots = React.createClass({
-  render() {
-    return (
-      <BigCalendar
-        {...this.props}
-        events={events}
-        step={15}
-        timeslots={8}
-        defaultView="week"
-        defaultDate={new Date(2015, 3, 12)}
-      />
-    )
-  },
-})
+let Timeslots = props => (
+  <BigCalendar
+    {...props}
+    events={events}
+    step={15}
+    timeslots={8}
+    defaultView="week"
+    defaultDate={new Date(2015, 3, 12)}
+  />
+)
 
 export default Timeslots


### PR DESCRIPTION
React 16 was introduced with https://github.com/intljusticemission/react-big-calendar/pull/671 , so we can't use `React.createClass` any more. This means neither stories or examples can be run at this point. I updated all the examples to use es6 instead, but (I think) the `markdown-jsx-loader` still uses `React.createClass`, so that package will also have to be updated before stories and examples work again.