### PR TITLE
Update react-related dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "prop-types": "^15.5.8",
     "react-overlays": "^0.7.0",
     "react-prop-types": "^0.4.0",
-    "uncontrollable": "^3.3.1 || ^4.0.0",
+    "uncontrollable": "^4.1.0",
     "warning": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "less-loader": "^4.0.5",
     "less-plugin-autoprefix": "^1.5.1",
     "lint-staged": "^6.0.0",
-    "markdown-jsx-loader": "^2.0.1",
+    "markdown-jsx-loader": "^3.0.0",
     "marked": "^0.3.5",
     "moment": "^2.17.1",
     "mt-changelog": "^0.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5280,17 +5280,22 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
-markdown-jsx-loader@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/markdown-jsx-loader/-/markdown-jsx-loader-2.0.1.tgz#290dced67f8a08d4582a42d47605e21e70a96edf"
+markdown-jsx-loader@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-jsx-loader/-/markdown-jsx-loader-3.0.0.tgz#c4b75260d64dbba435838998854409900534a5d2"
   dependencies:
     case "^1.3.2"
-    marked "^0.3.5"
+    loader-utils "^1.1.0"
+    marked "^0.3.6"
     prismjs "^1.3.0"
 
 marked@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
+
+marked@^0.3.6:
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.9.tgz#54ce6a57e720c3ac6098374ec625fcbcc97ff290"
 
 math-expression-evaluator@^1.2.14:
   version "1.2.17"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8044,9 +8044,15 @@ unc-path-regex@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
 
-uncontrollable@^3.1.3, "uncontrollable@^3.3.1 || ^4.0.0":
+uncontrollable@^3.1.3:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-3.3.1.tgz#e23b402e7a4c69b1853fb4b43ce34b6480c65b6f"
+  dependencies:
+    invariant "^2.1.0"
+
+uncontrollable@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-4.1.0.tgz#e0358291252e1865222d90939b19f2f49f81c1a9"
   dependencies:
     invariant "^2.1.0"
 


### PR DESCRIPTION
In #671 React was updated to v16. But the app is crashing after that. We have 2 ways:
1) Revert v16 update
2) Fix crashes. This PR is about it

`uncontorllable` and `markdown-jsx-loader` should be updated, as they use React.createClass in v3

But we have another problem - `markdown-jsx-loader` v3.0.0 is braking. It failes webpack build with `BabelLoaderError: SyntaxError: Unexpected token, expected ;` error (even for empty markdown file!). @jquense look into that. It's critical
