### PR TITLE
fixed non selectable events on weekly view

### DIFF
--- a/src/less/event.less
+++ b/src/less/event.less
@@ -6,6 +6,7 @@
   background-color: @event-bg;
   border-radius: @event-border-radius;
   color: @event-color;
+  pointer-events: all;
 
   &.rbc-selected {
     background-color: darken(@event-bg, 10%);


### PR DESCRIPTION
After some recent changes, events became unselectable on weekly view if not using drag and drop.