### PR TITLE
Update display of time indicator

### DIFF
--- a/examples/events.js
+++ b/examples/events.js
@@ -91,4 +91,10 @@ export default [
     start: new Date(2015, 3, 20, 19, 30, 0),
     end: new Date(2015, 3, 22, 2, 0, 0),
   },
+  {
+    id: 14,
+    title: 'Today',
+    start: new Date(new Date().setHours(new Date().getHours() - 3)),
+    end: new Date(new Date().setHours(new Date().getHours() + 3)),
+  },
 ]

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -206,10 +206,6 @@ export default class TimeGrid extends Component {
 <<<<<<< 3903fd7066dafcc7dd528fa9889748cf75e0e5df
 =======
           <div ref="timeIndicator" className="rbc-current-time-indicator" />
-          <div
-            ref="timeIndicatorLine"
-            className="rbc-current-time-indicator-line"
-          />
 
 >>>>>>> Update display of time indicator
           <TimeColumn
@@ -494,7 +490,6 @@ export default class TimeGrid extends Component {
     const secondsPassed = dates.diff(current, min, 'seconds')
 
     const timeIndicator = this.refs.timeIndicator
-    const timeIndicatorLine = this.refs.timeIndicatorLine
     const factor = secondsPassed / secondsGrid
     const timeGutter = this._gutters[this._gutters.length - 1]
 
@@ -507,21 +502,14 @@ export default class TimeGrid extends Component {
       const dayOffset = range.findIndex(d => dates.isToday(d)) * dayPixelWidth
       const offset = Math.floor(factor * pixelHeight)
 
-      timeIndicator.style.display = 'block'
+      timeIndicator.style.display = dayOffset >= 0 ? 'block' : 'none'
       timeIndicator.style[rtl ? 'left' : 'right'] = 0
       timeIndicator.style[rtl ? 'right' : 'left'] =
-        timeGutter.offsetWidth + 'px'
-      timeIndicator.style.top = offset + 'px'
-
-      timeIndicatorLine.style.display = dayOffset >= 0 ? 'block' : 'none'
-      timeIndicatorLine.style[rtl ? 'left' : 'right'] = 0
-      timeIndicatorLine.style[rtl ? 'right' : 'left'] =
         timeGutter.offsetWidth + dayOffset + 'px'
-      timeIndicatorLine.style.top = offset + 'px'
-      timeIndicatorLine.style.width = dayPixelWidth + 'px'
+      timeIndicator.style.top = offset + 'px'
+      timeIndicator.style.width = dayPixelWidth + 'px'
     } else {
       timeIndicator.style.display = 'none'
-      timeIndicatorLine.style.display = 'none'
     }
   }
 

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -203,6 +203,15 @@ export default class TimeGrid extends Component {
         {this.renderHeader(range, allDayEvents, width, resources)}
 
         <div ref="content" className="rbc-time-content">
+<<<<<<< 3903fd7066dafcc7dd528fa9889748cf75e0e5df
+=======
+          <div ref="timeIndicator" className="rbc-current-time-indicator" />
+          <div
+            ref="timeIndicatorLine"
+            className="rbc-current-time-indicator-line"
+          />
+
+>>>>>>> Update display of time indicator
           <TimeColumn
             {...this.props}
             showLabels
@@ -478,18 +487,24 @@ export default class TimeGrid extends Component {
   }
 
   positionTimeIndicator() {
-    const { rtl, min, max, getNow } = this.props
+    const { rtl, min, max, getNow, range } = this.props
     const current = getNow()
 
     const secondsGrid = dates.diff(max, min, 'seconds')
     const secondsPassed = dates.diff(current, min, 'seconds')
 
     const timeIndicator = this.refs.timeIndicator
+    const timeIndicatorLine = this.refs.timeIndicatorLine
     const factor = secondsPassed / secondsGrid
     const timeGutter = this._gutters[this._gutters.length - 1]
 
+    const content = this.refs.content
+
     if (timeGutter && current >= min && current <= max) {
       const pixelHeight = timeGutter.offsetHeight
+      const dayPixelWidth =
+        (content.offsetWidth - timeGutter.offsetWidth) / this.slots
+      const dayOffset = range.findIndex(d => dates.isToday(d)) * dayPixelWidth
       const offset = Math.floor(factor * pixelHeight)
 
       timeIndicator.style.display = 'block'
@@ -497,8 +512,16 @@ export default class TimeGrid extends Component {
       timeIndicator.style[rtl ? 'right' : 'left'] =
         timeGutter.offsetWidth + 'px'
       timeIndicator.style.top = offset + 'px'
+
+      timeIndicatorLine.style.display = dayOffset >= 0 ? 'block' : 'none'
+      timeIndicatorLine.style[rtl ? 'left' : 'right'] = 0
+      timeIndicatorLine.style[rtl ? 'right' : 'left'] =
+        timeGutter.offsetWidth + dayOffset + 'px'
+      timeIndicatorLine.style.top = offset + 'px'
+      timeIndicatorLine.style.width = dayPixelWidth + 'px'
     } else {
       timeIndicator.style.display = 'none'
+      timeIndicatorLine.style.display = 'none'
     }
   }
 

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -203,11 +203,6 @@ export default class TimeGrid extends Component {
         {this.renderHeader(range, allDayEvents, width, resources)}
 
         <div ref="content" className="rbc-time-content">
-<<<<<<< 3903fd7066dafcc7dd528fa9889748cf75e0e5df
-=======
-          <div ref="timeIndicator" className="rbc-current-time-indicator" />
-
->>>>>>> Update display of time indicator
           <TimeColumn
             {...this.props}
             showLabels
@@ -499,7 +494,8 @@ export default class TimeGrid extends Component {
       const pixelHeight = timeGutter.offsetHeight
       const dayPixelWidth =
         (content.offsetWidth - timeGutter.offsetWidth) / this.slots
-      const dayOffset = range.findIndex(d => dates.isToday(d)) * dayPixelWidth
+      const dayOffset =
+        range.findIndex(d => dates.eq(d, dates.today(), 'day')) * dayPixelWidth
       const offset = Math.floor(factor * pixelHeight)
 
       timeIndicator.style.display = dayOffset >= 0 ? 'block' : 'none'

--- a/src/less/time-grid.less
+++ b/src/less/time-grid.less
@@ -112,6 +112,7 @@
 
 .rbc-current-time-indicator {
   position: absolute;
+<<<<<<< a8b159d80c8825b79dec987ed5eecaf91bd41be9
   left: 0;
   height: 1px;
   width: 1px;
@@ -142,7 +143,7 @@
 
 .rbc-current-time-indicator-line {
   position: absolute;
-  z-index: 1;
+  z-index: 3;
   height: 1px;
 
   background-color: @current-time-color;

--- a/src/less/time-grid.less
+++ b/src/less/time-grid.less
@@ -114,6 +114,7 @@
   position: absolute;
   left: 0;
   height: 1px;
+  width: 1px;
 
   background-color: @current-time-color;
   pointer-events: none;
@@ -137,4 +138,13 @@
     left: 0;
     right: -3px;
   }
+}
+
+.rbc-current-time-indicator-line {
+  position: absolute;
+  z-index: 1;
+  height: 1px;
+
+  background-color: @current-time-color;
+  pointer-events: none;
 }

--- a/src/less/time-grid.less
+++ b/src/less/time-grid.less
@@ -112,37 +112,6 @@
 
 .rbc-current-time-indicator {
   position: absolute;
-<<<<<<< a8b159d80c8825b79dec987ed5eecaf91bd41be9
-  left: 0;
-  height: 1px;
-  width: 1px;
-
-  background-color: @current-time-color;
-  pointer-events: none;
-
-  &::before {
-    display: block;
-
-    position: absolute;
-    left: -3px;
-    top: -3px;
-
-    content: ' ';
-    background-color: @current-time-color;
-
-    border-radius: 50%;
-    width: 8px;
-    height: 8px;
-  }
-
-  .rbc-rtl &::before {
-    left: 0;
-    right: -3px;
-  }
-}
-
-.rbc-current-time-indicator-line {
-  position: absolute;
   z-index: 3;
   height: 1px;
 


### PR DESCRIPTION
Update time indicator to only show the bar on the current day instead of the full week.
This behavior is more consistent with gcal and is less confusing when looking at the calendar

![screen shot 2018-01-24 at 4 08 34 pm](https://user-images.githubusercontent.com/1156460/35357329-2c5e4128-0121-11e8-811a-4409f2109496.png)

![screen shot 2018-01-24 at 4 08 40 pm](https://user-images.githubusercontent.com/1156460/35357335-3127ea92-0121-11e8-9655-1dd7c85e06ff.png)
