### PR TITLE
Fix dnd style preventing event from dropping on itself

### DIFF
--- a/src/addons/dragAndDrop/styles.less
+++ b/src/addons/dragAndDrop/styles.less
@@ -5,7 +5,7 @@
     pointer-events: none;
 
     & .rbc-show-more,
-    & .rbc-event:not(.rbc-addons-dnd-dragging) {
+    & .rbc-event {
       pointer-events: all;
     }
   }
@@ -32,11 +32,6 @@
     pointer-events: none;
     opacity: .50;
   }
-
-  // .rbc-addons-dnd-dragging {
-  //   pointer-events: none;
-  //   opacity: .35;
-  // }
 
   .rbc-addons-dnd-resize-anchor {
     width: 100%;


### PR DESCRIPTION
## Description

This PR is to fix the issue related to not being able to drop an event onto itself when resizing an event to be smaller than its current length. I removed the related styling that was preventing this and the app now works as expected.

## Screentshot

<a href="https://cl.ly/3Z3c0I0N1225" target="_blank"><img src="https://dha4w82d62smt.cloudfront.net/items/3f3G0G400x2T3n2V3f3s/Screen%20Recording%202018-02-12%20at%2010.46%20AM.gif" style="display: block;height: auto;width: 100%;"/></a>

## Issue
#656 