### PR TITLE
use recompose, use unix timestamps

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "prop-types": "^15.5.8",
     "react-overlays": "^0.7.0",
     "react-prop-types": "^0.4.0",
+    "recompose": "^0.26.0",
     "uncontrollable": "^4.0.0",
     "warning": "^2.0.0"
   }

--- a/src/TimeSlot.js
+++ b/src/TimeSlot.js
@@ -2,8 +2,9 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import cn from 'classnames'
 import { elementType } from './utils/propTypes'
+import { onlyUpdateForPropTypes } from 'recompose'
 
-export default class TimeSlot extends Component {
+class TimeSlot extends Component {
   static propTypes = {
     dayWrapperComponent: elementType,
     value: PropTypes.instanceOf(Date).isRequired,
@@ -43,3 +44,5 @@ export default class TimeSlot extends Component {
     )
   }
 }
+
+export default onlyUpdateForPropTypes(TimeSlot)


### PR DESCRIPTION
Hey, I'm using react-big-calendar and I'm seeing performance hits when using many events and/or many resources.

I noticed that for example a change to the events array will cause a lot of components to update, even though their props don't really change (e.g. TimeSlot); or any prop change will cause all events to recalculate and rerender. This is caused by missing shouldComponentUpdate/PureComponent as well as declaration of arrays and dates inside render functions and handing those to child components as props.

There is a few things that could be optimized:
- Outsource expensive calculations out of render (use withPropsOnChange from recompose?) to avoid unnecessary recalculations and unnecessary rerendering of child components
- Avoid date types (use unix timestamps +new Date() since they are much easier to compare)
- Use PureComponent
- Small stuff like avoiding inline functions, object declarations and the likes in render functions

This PR introduces recompose withPropsOnChange, unix date and other small optimizations, but it is only a start. There is many other places that would benefit, but will need to be revisited.

I'd like to use this as a discussion start, so let me know what you think of this.

I've published this packaged as `react-big-calendar-opt`, so feel free to try it, especially with 4x throttling enabled in chrome devtools.