### PR TITLE
Add title to headers

### DIFF
--- a/src/Header.js
+++ b/src/Header.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 const Header = ({ label }) => {
-  return <span>{label}</span>
+  return <span title={label}>{label}</span>
 }
 
 Header.propTypes = {

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -338,6 +338,7 @@ export default class TimeGrid extends Component {
     const today = getNow()
     return range.map((date, i) => {
       return resources.map((resource, j) => {
+        const resourceName = get(resource, resourceTitleAccessor)
         return (
           <div
             key={i + '-' + j}
@@ -347,7 +348,7 @@ export default class TimeGrid extends Component {
             )}
             style={segStyle(1, this.slots)}
           >
-            <span>{get(resource, resourceTitleAccessor)}</span>
+            <span title={resourceName}>{resourceName}</span>
           </div>
         )
       })


### PR DESCRIPTION
For the resource view, sometimes the label is too small for the header cell and cuts off. It's impossible to tell what the header is when the labels have the same prefixes.

Example header

- Guitar Private Lesson Level I
- Guitar Private Lesson Level II
- Guitar Private Lesson Level III

Those get cut off like this

- Guitar Private Les...
- Guitar Private Les...
- Guitar Private Les...

So you don't know what level they are. Having a title for the resources so that you can hover over and see the full label helps solve this issue. I also added a title to the date header for consistency.