### PR TITLE
Add width property on the return value of segStyle method

### DIFF
--- a/src/utils/eventLevels.js
+++ b/src/utils/eventLevels.js
@@ -36,7 +36,7 @@ export function eventSegments(
 
 export function segStyle(span, slots) {
   let per = span / slots * 100 + '%'
-  return { WebkitFlexBasis: per, flexBasis: per, maxWidth: per } // IE10/11 need max-width. flex-basis doesn't respect box-sizing
+  return { WebkitFlexBasis: per, flexBasis: per, maxWidth: per, width: per } // IE10/11 need max-width. flex-basis doesn't respect box-sizing
 }
 
 export function eventLevels(rowSegments, limit = Infinity) {


### PR DESCRIPTION
Thanks for making this amazing library. But I found an issue while I was testing on IE10.

When the view prop if set to 'month', the element of 'rbc-row-segment' className is not correctly positioned.

The reason for this behavior is because the 'flex-basis' attribute is not supported on IE10. And I found 'max-width' is present in the current code to compensate this behavior. But 'max-width' doesn't work without 'width' attribute as you may already know.

I tried to fix this by adding 'width: 100%' for '.rbc-row-segment' class on my CSS file. But wouldn't it be better if we add width attribute directly on the element as if you set the styles on segStyle function? So others don't have to add this attribute to their CSS file.