### PR TITLE
Add box and bound to onSelectSlot callback

### DIFF
--- a/src/BackgroundCells.js
+++ b/src/BackgroundCells.js
@@ -123,6 +123,7 @@ class BackgroundCells extends React.Component {
             startIdx: currentCell,
             endIdx: currentCell,
             action: actionType,
+            box: point,
           })
         }
       }
@@ -171,8 +172,8 @@ class BackgroundCells extends React.Component {
       selectorClicksHandler(point, 'doubleClick')
     )
 
-    selector.on('select', () => {
-      this._selectSlot({ ...this.state, action: 'select' })
+    selector.on('select', bounds => {
+      this._selectSlot({ ...this.state, action: 'select', bounds })
       this._initial = {}
       this.setState({ selecting: false })
       notify(this.props.onSelectEnd, [this.state])
@@ -185,13 +186,14 @@ class BackgroundCells extends React.Component {
     this._selector = null
   }
 
-  _selectSlot({ endIdx, startIdx, action }) {
+  _selectSlot({ endIdx, startIdx, action, bounds }) {
     if (endIdx !== -1 && startIdx !== -1)
       this.props.onSelectSlot &&
         this.props.onSelectSlot({
           start: startIdx,
           end: endIdx,
           action,
+          bounds,
         })
   }
 }

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -260,7 +260,21 @@ class Calendar extends React.Component {
      *     start: Date,
      *     end: Date,
      *     slots: Array<Date>,
-     *     action: "select" | "click" | "doubleClick"
+     *     action: "select" | "click" | "doubleClick",
+     *     bounds: ?{ // For "select" action
+     *       x: number,
+     *       y: number,
+     *       top: number,
+     *       right: number,
+     *       left: number,
+     *       bottom: number,
+     *     },
+     *     box: ?{ // For "click" or "doubleClick" actions
+     *       clientX: number,
+     *       clientY: number,
+     *       x: number,
+     *       y: number,
+     *     },
      *   }
      * ) => any
      * ```

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -336,7 +336,11 @@ class DayColumn extends React.Component {
 
     let selectorClicksHandler = (box, actionType) => {
       if (!isEvent(findDOMNode(this), box))
-        this._selectSlot({ ...selectionState(box), action: actionType })
+        this._selectSlot({
+          ...selectionState(box),
+          action: actionType,
+          box,
+        })
 
       this.setState({ selecting: false })
     }
@@ -354,9 +358,9 @@ class DayColumn extends React.Component {
 
     selector.on('doubleClick', box => selectorClicksHandler(box, 'doubleClick'))
 
-    selector.on('select', () => {
+    selector.on('select', bounds => {
       if (this.state.selecting) {
-        this._selectSlot({ ...this.state, action: 'select' })
+        this._selectSlot({ ...this.state, action: 'select', bounds })
         this.setState({ selecting: false })
       }
     })
@@ -368,7 +372,7 @@ class DayColumn extends React.Component {
     this._selector = null
   }
 
-  _selectSlot = ({ startDate, endDate, action }) => {
+  _selectSlot = ({ startDate, endDate, action, bounds, box }) => {
     let current = startDate,
       slots = []
 
@@ -383,6 +387,8 @@ class DayColumn extends React.Component {
       end: endDate,
       resourceId: this.props.resource,
       action,
+      bounds,
+      box,
     })
   }
 


### PR DESCRIPTION
I want to render an in-line popup at the `{x,y}` coordinates of the selection event, so passing back the `box` (for clicks) and the `bounds` (for select) makes this possible.