### PR TITLE
Don't call setState too often on selection

### DIFF
--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -300,7 +300,11 @@ class DayColumn extends React.Component {
           return
       }
 
-      this.setState(state)
+      if (this.state.startSlot !== state.startSlot
+        || this.state.endSlot !== state.endSlot
+        || this.state.selecting !== state.selecting) {
+        this.setState(state);
+      }
     }
 
     let selectionState = ({ y }) => {


### PR DESCRIPTION
This causes a many unnecessary `render()` of `DayColumn` calls, which leads to high CPU usage on IE11.