### PR TITLE
Add box arg to _selectSlot on BackgroundCells.js

### DIFF
--- a/src/BackgroundCells.js
+++ b/src/BackgroundCells.js
@@ -183,7 +183,7 @@ class BackgroundCells extends React.Component {
     this._selector = null
   }
 
-  _selectSlot({ endIdx, startIdx, action, bounds }) {
+  _selectSlot({ endIdx, startIdx, action, bounds, box }) {
     if (endIdx !== -1 && startIdx !== -1)
       this.props.onSelectSlot &&
         this.props.onSelectSlot({
@@ -191,6 +191,7 @@ class BackgroundCells extends React.Component {
           end: endIdx,
           action,
           bounds,
+          box,
         })
   }
 }


### PR DESCRIPTION
I think I missed this in my first PR, so some click events are not passing through the `box` properly