### PR TITLE
Fix to prevent scrollToTime from being recalculated when it shouldn't

### DIFF
--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -123,8 +123,8 @@ export default class TimeGrid extends Component {
     const { range, scrollToTime } = this.props
     // When paginating, reset scroll
     if (
-      !_moment(nextProps.range[0]).isSame(range[0], 'minute') ||
-      !_moment(nextProps.scrollToTime).isSame(scrollToTime, 'minute')
+      !moment(nextProps.range[0]).isSame(range[0], 'minute') ||
+      !moment(nextProps.scrollToTime).isSame(scrollToTime, 'minute')
     ) {
       this.calculateScroll(nextProps)
     }

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -5,6 +5,7 @@ import React, { Component } from 'react'
 import { findDOMNode } from 'react-dom'
 
 import dates from './utils/dates'
+import moment from 'moment'
 import DayColumn from './DayColumn'
 import TimeGutter from './TimeGutter'
 
@@ -122,8 +123,8 @@ export default class TimeGrid extends Component {
     const { range, scrollToTime } = this.props
     // When paginating, reset scroll
     if (
-      !dates.eq(nextProps.range[0], range[0], 'minute') ||
-      !dates.eq(nextProps.scrollToTime, scrollToTime, 'minute')
+      !_moment(nextProps.range[0]).isSame(range[0], 'minute') ||
+      !_moment(nextProps.scrollToTime).isSame(scrollToTime, 'minute')
     ) {
       this.calculateScroll(nextProps)
     }


### PR DESCRIPTION
`date-arithmentic`'s `eq()` method [doesn't actually accept a third param](https://github.com/jquense/date-math/blob/master/index.js#L85). Instead it does a full dttm compare. This causes the `scrollToTime` to be recalculated whenever any prop in the `TimeGrid` component changes. To fix this, we just use `moment().isSame()` instead.