### PR TITLE
Fixing TimeSlots getSlotMetrics

### DIFF
--- a/src/utils/TimeSlots.js
+++ b/src/utils/TimeSlots.js
@@ -28,7 +28,7 @@ export function getSlotMetrics({ min: start, max: end, step, timeslots }) {
   for (let grp = 0; grp < numGroups; grp++) {
     groups[grp] = new Array(timeslots)
 
-    for (let slot = 0; slot <= timeslots; slot++) {
+    for (let slot = 0; slot < timeslots; slot++) {
       const slotIdx = grp * timeslots + slot
       const minFromStart = slotIdx * step
       // A date with total minutes calculated from the start of the day
@@ -43,6 +43,19 @@ export function getSlotMetrics({ min: start, max: end, step, timeslots }) {
       )
     }
   }
+  
+  const lastSlotMinFromStart = slots.length * step
+  slots.push(
+    new Date(
+      start.getFullYear(),
+      start.getMonth(),
+      start.getDate(),
+      0,
+      minutesFromMidnight + lastSlotMinFromStart,
+      0,
+      0
+    )
+  )
 
   function positionFromDate(date) {
     const diff = dates.diff(start, date, 'minutes') + getDstOffset(start, date)

--- a/src/utils/TimeSlots.js
+++ b/src/utils/TimeSlots.js
@@ -28,7 +28,7 @@ export function getSlotMetrics({ min: start, max: end, step, timeslots }) {
   for (let grp = 0; grp < numGroups; grp++) {
     groups[grp] = new Array(timeslots)
 
-    for (let slot = 0; slot < timeslots; slot++) {
+    for (let slot = 0; slot <= timeslots; slot++) {
       const slotIdx = grp * timeslots + slot
       const minFromStart = slotIdx * step
       // A date with total minutes calculated from the start of the day

--- a/src/utils/TimeSlots.js
+++ b/src/utils/TimeSlots.js
@@ -43,7 +43,8 @@ export function getSlotMetrics({ min: start, max: end, step, timeslots }) {
       )
     }
   }
-  
+
+  // Necessary to be able to select up until the last timeslot in a day
   const lastSlotMinFromStart = slots.length * step
   slots.push(
     new Date(

--- a/src/utils/TimeSlots.js
+++ b/src/utils/TimeSlots.js
@@ -87,7 +87,10 @@ export function getSlotMetrics({ min: start, max: end, step, timeslots }) {
     },
 
     closestSlotToPosition(percent) {
-      const slot = Math.max(0, Math.floor(percent * numSlots))
+      const slot = Math.min(
+        slots.length - 1,
+        Math.max(0, Math.floor(percent * numSlots))
+      )
       return slots[slot]
     },
 

--- a/test/utils/TimeSlots.test.js
+++ b/test/utils/TimeSlots.test.js
@@ -1,0 +1,24 @@
+import { getSlotMetrics } from '../../src/utils/TimeSlots'
+import dates from '../../src/utils/dates'
+
+describe('getSlotMetrics', () => {
+  const min = dates.startOf(new Date(), 'day')
+  const max = dates.endOf(new Date(), 'day')
+  const slotMetrics = getSlotMetrics({ min, max, step: 60, timeslots: 1 })
+  test('getSlotMetrics.closestSlotToPosition: always returns timeslot if valid percentage is given', () => {
+    expect(slotMetrics.closestSlotToPosition(0)).toBeDefined()
+    expect(slotMetrics.closestSlotToPosition(1)).toBeDefined()
+    expect(slotMetrics.closestSlotToPosition(100)).toBeDefined()
+    expect(slotMetrics.closestSlotToPosition(-100)).toBeDefined()
+    expect(slotMetrics.closestSlotToPosition()).toBeUndefined()
+    expect(slotMetrics.closestSlotToPosition('asd')).toBeUndefined()
+  })
+
+  test('getSlotMetrics.closestSlotToPosition: returns last timeslot with correct time', () => {
+    const secondLastSlot = slotMetrics.groups[slotMetrics.groups.length - 1][0]
+    const shouldBeLast = slotMetrics.closestSlotToPosition(1)
+    const diff = dates.diff(secondLastSlot, shouldBeLast, 'minutes')
+
+    expect(diff).toBe(60)
+  })
+})


### PR DESCRIPTION
I was about to make an issue, but figured I could create a pull request instead.

The issue I was about to post:

> #### Do you want to request a _feature_ or report a _bug_?
> Bug
> 
> #### What's the current behavior?
> The new TimeSlots metrics generate the wrong number of timeslots, so the last timeslot is not included (the one that goes to 23:59), making it unselectable. You can see it here:
> 
> - [CodeSandbox](https://codesandbox.io/s/13kqjp5o43)
> - http://g.recordit.co/Sy5qUDTpya.gif
> 
> I've also tested this with any given `min` and `max` value, the same happens, so it isn't just 23:59 timeslot that is excluded. 
> 
> #### What's the expected behavior?
> The last timeslot in any given day should be selectable.

This change should fix this issue. I've tested it with multiple configurations of `min`, `max` and `timeslots`, and the issue was present for all of them and fixed with this change for all of them
