### PR TITLE
Add declaration file to dnd in addons

### DIFF
--- a/src/addons/dragAndDrop/index.d.ts
+++ b/src/addons/dragAndDrop/index.d.ts
@@ -1,0 +1,2 @@
+declare const withDragAndDrop: (x: any) => any;
+export default withDragAndDrop;


### PR DESCRIPTION
- If you want to use dnd from addons folder in typescript, current @types/react-big-calendar does not provide any declarations for using it. That's why this declaration file can help people using typescript.