### PR TITLE
DnD support for custom DropWrapper components (dayWrapper and dateCellWrapper)

### DIFF
--- a/examples/demos/customView.js
+++ b/examples/demos/customView.js
@@ -49,7 +49,7 @@ MyWeek.title = date => {
 let CustomView = () => (
   <BigCalendar
     events={events}
-    defaultView="week"
+    defaultView={BigCalendar.Views.WEEK}
     defaultDate={new Date(2015, 3, 1)}
     views={{ month: true, week: MyWeek }}
   />

--- a/examples/demos/dnd.js
+++ b/examples/demos/dnd.js
@@ -59,7 +59,7 @@ class Dnd extends React.Component {
         onEventDrop={this.moveEvent}
         resizable
         onEventResize={this.resizeEvent}
-        defaultView="week"
+        defaultView={BigCalendar.Views.WEEK}
         defaultDate={new Date(2015, 3, 12)}
       />
     )

--- a/examples/demos/rendering.js
+++ b/examples/demos/rendering.js
@@ -43,7 +43,7 @@ let Rendering = () => (
   <BigCalendar
     events={events}
     defaultDate={new Date(2015, 3, 1)}
-    defaultView="agenda"
+    defaultView={BigCalendar.Views.AGENDA}
     dayPropGetter={customDayPropGetter}
     slotPropGetter={customSlotPropGetter}
     components={{

--- a/examples/demos/resource.js
+++ b/examples/demos/resource.js
@@ -43,7 +43,7 @@ const resourceMap = [
 let Resource = () => (
   <BigCalendar
     events={events}
-    defaultView="day"
+    defaultView={BigCalendar.Views.DAY}
     views={['day', 'work_week']}
     step={60}
     defaultDate={new Date(2018, 0, 29)}

--- a/examples/demos/selectable.js
+++ b/examples/demos/selectable.js
@@ -11,7 +11,7 @@ let Selectable = () => (
     <BigCalendar
       selectable
       events={events}
-      defaultView="week"
+      defaultView={BigCalendar.Views.WEEK}
       scrollToTime={new Date(1970, 1, 1, 6)}
       defaultDate={new Date(2015, 3, 12)}
       onSelectEvent={event => alert(event.title)}

--- a/examples/demos/timeslots.js
+++ b/examples/demos/timeslots.js
@@ -7,7 +7,7 @@ let Timeslots = () => (
     events={events}
     step={15}
     timeslots={8}
-    defaultView="week"
+    defaultView={BigCalendar.Views.WEEK}
     defaultDate={new Date(2015, 3, 12)}
   />
 )

--- a/src/addons/dragAndDrop/DropWrappers.js
+++ b/src/addons/dragAndDrop/DropWrappers.js
@@ -39,8 +39,10 @@ function getEventDropProps(start, end, dropDate, droppedInAllDay) {
 class DropWrapper extends React.Component {
   static propTypes = {
     connectDropTarget: PropTypes.func.isRequired,
-    type: PropTypes.string,
     isOver: PropTypes.bool,
+    range: PropTypes.arrayOf(PropTypes.instanceOf(Date)),
+    type: PropTypes.string,
+    value: PropTypes.instanceOf(Date),
   }
 
   static contextTypes = {
@@ -99,20 +101,35 @@ class DropWrapper extends React.Component {
   // };
 
   render() {
-    const { connectDropTarget, children, type, isOver } = this.props
+    const {
+      connectDropTarget,
+      children,
+      isOver,
+      range,
+      type,
+      value,
+    } = this.props
 
     // Check if wrapper component of this type was passed in, otherwise use library default
     const { components } = this.context
     const BackgroundWrapper = components[type] || BigCalendar.components[type]
+    const backgroundWrapperProps = {
+      value,
+    }
+
+    if (range) {
+      backgroundWrapperProps.range = range
+    }
 
     let resultingChildren = children
-    if (isOver)
+    if (isOver) {
       resultingChildren = React.cloneElement(children, {
         className: cn(children.props.className, 'rbc-addons-dnd-over'),
       })
+    }
 
     return (
-      <BackgroundWrapper>
+      <BackgroundWrapper {...backgroundWrapperProps}>
         {connectDropTarget(resultingChildren)}
       </BackgroundWrapper>
     )

--- a/src/addons/dragAndDrop/DropWrappers.js
+++ b/src/addons/dragAndDrop/DropWrappers.js
@@ -16,12 +16,12 @@ function getEventDropProps(start, end, dropDate, droppedInAllDay) {
   /*
    * If the event is dropped in a "Day" cell, preserve an event's start time by extracting the hours and minutes off
    * the original start date and add it to newDate.value
-   * 
+   *
    * note: this behavior remains for backward compatibility, but might be counter-intuitive to some:
    * dragging an event from the grid to the day header might more commonly mean "make this an allDay event
    * on that day" - but the behavior here implements "keep the times of the event, but move it to the
    * new day".
-   * 
+   *
    * To permit either interpretation, we embellish a new `allDay` parameter which determines whether the
    * event was dropped on the day header or not.
    */
@@ -46,6 +46,7 @@ class DropWrapper extends React.Component {
   static contextTypes = {
     onEventDrop: PropTypes.func,
     onEventResize: PropTypes.func,
+    components: PropTypes.object,
     dragDropManager: PropTypes.object,
     startAccessor: accessor,
     endAccessor: accessor,
@@ -99,7 +100,10 @@ class DropWrapper extends React.Component {
 
   render() {
     const { connectDropTarget, children, type, isOver } = this.props
-    const BackgroundWrapper = BigCalendar.components[type]
+
+    // Check if wrapper component of this type was passed in, otherwise use library default
+    const { components } = this.context
+    const BackgroundWrapper = components[type] || BigCalendar.components[type]
 
     let resultingChildren = children
     if (isOver)

--- a/src/addons/dragAndDrop/withDragAndDrop.js
+++ b/src/addons/dragAndDrop/withDragAndDrop.js
@@ -52,8 +52,9 @@ try {
  * If you care about these corner cases, you can examine the `allDay` param suppled
  * in the callback to determine how the user dropped or resized the event.
  *
- * Note: you cannot use custom `EventWrapper`, `DayWrapper` or `DateCellWrapper`
- * components when using this HOC as they are overwritten here.
+ * Note: you cannot use custom `EventWrapper` components when using this HOC as it
+ * is overwritten here.
+ *
  *
  * @param {*} Calendar
  * @param {*} backend

--- a/src/addons/dragAndDrop/withDragAndDrop.js
+++ b/src/addons/dragAndDrop/withDragAndDrop.js
@@ -78,6 +78,7 @@ export default function withDragAndDrop(
 
     static defaultProps = {
       // TODO: pick these up from Calendar.defaultProps
+      components: {},
       startAccessor: 'start',
       endAccessor: 'end',
       allDayAccessor: 'allDay',
@@ -92,6 +93,7 @@ export default function withDragAndDrop(
     static childContextTypes = {
       onEventDrop: PropTypes.func,
       onEventResize: PropTypes.func,
+      components: PropTypes.object,
       startAccessor: accessor,
       endAccessor: accessor,
       draggableAccessor: accessor,
@@ -102,6 +104,7 @@ export default function withDragAndDrop(
       return {
         onEventDrop: this.props.onEventDrop,
         onEventResize: this.props.onEventResize,
+        components: this.props.components,
         startAccessor: this.props.startAccessor,
         endAccessor: this.props.endAccessor,
         step: this.props.step,

--- a/stories/Calendar.js
+++ b/stories/Calendar.js
@@ -8,6 +8,7 @@ import '../src/less/styles.less'
 import '../src/addons/dragAndDrop/styles.less'
 import demoEvents from '../examples/events'
 import createEvents from './createEvents'
+import customComponents from './customComponents'
 import resources from './resourceEvents'
 import withDragAndDrop from '../src/addons/dragAndDrop'
 
@@ -373,33 +374,27 @@ storiesOf('module.Calendar.week', module)
     )
   })
   .add('add custom dateCellWrapper', () => {
-    const components = {
-      dateCellWrapper: props => {
-        const hasAlert = Math.random() <= 1 / 3
-        const style = {
-          display: 'flex',
-          flex: 1,
-          borderLeft: '1px solid #DDD',
-          backgroundColor: hasAlert ? 'green' : '#fff',
-        }
-        return (
-          <div style={style}>
-            {hasAlert && (
-              <a onClick={action('custom dateCellWrapper component clicked')}>
-                Click me
-              </a>
-            )}
-            {props.children}
-          </div>
-        )
-      },
-    }
     return (
       <div style={{ height: 600 }}>
         <Calendar
           defaultView={Calendar.Views.MONTH}
           events={events}
-          components={components}
+          components={{
+            dateCellWrapper: customComponents.dateCellWrapper,
+          }}
+        />
+      </div>
+    )
+  })
+  .add('add custom dayWrapper', () => {
+    return (
+      <div style={{ height: 600 }}>
+        <Calendar
+          defaultView={Calendar.Views.DAY}
+          events={events}
+          components={{
+            dayWrapper: customComponents.dayWrapper,
+          }}
         />
       </div>
     )
@@ -594,33 +589,32 @@ storiesOf('module.Calendar.week', module)
     )
   })
   .add('draggable and resizable with custom dateCellWrapper', () => {
-    const components = {
-      dateCellWrapper: props => {
-        const hasAlert = Math.random() <= 1 / 3
-        const style = {
-          display: 'flex',
-          flex: 1,
-          borderLeft: '1px solid #DDD',
-          backgroundColor: hasAlert ? 'green' : '#fff',
-        }
-        return (
-          <div style={style}>
-            {hasAlert && (
-              <a onClick={action('custom dateCellWrapper component clicked')}>
-                Click me
-              </a>
-            )}
-            {props.children}
-          </div>
-        )
-      },
-    }
     return (
       <div style={{ height: 600 }}>
         <DragAndDropCalendar
-          components={components}
+          components={{
+            dateCellWrapper: customComponents.dateCellWrapper,
+          }}
           defaultDate={new Date()}
           defaultView={Calendar.Views.MONTH}
+          events={events}
+          resizable
+          showMultiDayTimes
+          onEventDrop={action('event dropped')}
+          onEventResize={action('event resized')}
+        />
+      </div>
+    )
+  })
+  .add('draggable and resizable with custom dayWrapper', () => {
+    return (
+      <div style={{ height: 600 }}>
+        <DragAndDropCalendar
+          components={{
+            dayWrapper: customComponents.dayWrapper,
+          }}
+          defaultDate={new Date()}
+          defaultView={Calendar.Views.WEEK}
           events={events}
           resizable
           showMultiDayTimes

--- a/stories/Calendar.js
+++ b/stories/Calendar.js
@@ -372,6 +372,38 @@ storiesOf('module.Calendar.week', module)
       </div>
     )
   })
+  .add('add custom dateCellWrapper', () => {
+    const components = {
+      dateCellWrapper: props => {
+        const hasAlert = Math.random() <= 1 / 3
+        const style = {
+          display: 'flex',
+          flex: 1,
+          borderLeft: '1px solid #DDD',
+          backgroundColor: hasAlert ? 'green' : '#fff',
+        }
+        return (
+          <div style={style}>
+            {hasAlert && (
+              <a onClick={action('custom dateCellWrapper component clicked')}>
+                Click me
+              </a>
+            )}
+            {props.children}
+          </div>
+        )
+      },
+    }
+    return (
+      <div style={{ height: 600 }}>
+        <Calendar
+          defaultView={Calendar.Views.MONTH}
+          events={events}
+          components={components}
+        />
+      </div>
+    )
+  })
   .add('no duration', () => {
     return (
       <div style={{ height: 600 }}>
@@ -552,6 +584,43 @@ storiesOf('module.Calendar.week', module)
         <DragAndDropCalendar
           defaultDate={new Date()}
           defaultView="week"
+          events={events}
+          resizable
+          showMultiDayTimes
+          onEventDrop={action('event dropped')}
+          onEventResize={action('event resized')}
+        />
+      </div>
+    )
+  })
+  .add('draggable and resizable with custom dateCellWrapper', () => {
+    const components = {
+      dateCellWrapper: props => {
+        const hasAlert = Math.random() <= 1 / 3
+        const style = {
+          display: 'flex',
+          flex: 1,
+          borderLeft: '1px solid #DDD',
+          backgroundColor: hasAlert ? 'green' : '#fff',
+        }
+        return (
+          <div style={style}>
+            {hasAlert && (
+              <a onClick={action('custom dateCellWrapper component clicked')}>
+                Click me
+              </a>
+            )}
+            {props.children}
+          </div>
+        )
+      },
+    }
+    return (
+      <div style={{ height: 600 }}>
+        <DragAndDropCalendar
+          components={components}
+          defaultDate={new Date()}
+          defaultView="month"
           events={events}
           resizable
           showMultiDayTimes

--- a/stories/Calendar.js
+++ b/stories/Calendar.js
@@ -119,7 +119,7 @@ storiesOf('module.Calendar.week', module)
     return (
       <div style={{ height: 600 }}>
         <Calendar
-          defaultView="week"
+          defaultView={Calendar.Views.WEEK}
           min={moment('12:00am', 'h:mma').toDate()}
           max={moment('11:59pm', 'h:mma').toDate()}
           events={events}
@@ -133,7 +133,7 @@ storiesOf('module.Calendar.week', module)
     return (
       <div style={{ height: 600 }}>
         <DragableCalendar
-          defaultView="day"
+          defaultView={Calendar.Views.DAY}
           min={moment('12:00am', 'h:mma').toDate()}
           max={moment('11:59pm', 'h:mma').toDate()}
           events={[
@@ -181,7 +181,7 @@ storiesOf('module.Calendar.week', module)
     return (
       <div style={{ height: 600 }}>
         <Calendar
-          defaultView="week"
+          defaultView={Calendar.Views.WEEK}
           selectable
           min={moment('12:00am', 'h:mma').toDate()}
           max={moment('11:59pm', 'h:mma').toDate()}
@@ -197,7 +197,7 @@ storiesOf('module.Calendar.week', module)
     return (
       <div style={{ height: 600 }}>
         <Calendar
-          defaultView="week"
+          defaultView={Calendar.Views.WEEK}
           selectable
           timeslots={4}
           step={15}
@@ -215,7 +215,7 @@ storiesOf('module.Calendar.week', module)
     return (
       <div style={{ height: 600 }}>
         <Calendar
-          defaultView="week"
+          defaultView={Calendar.Views.WEEK}
           selectable
           timeslots={6}
           step={10}
@@ -233,7 +233,7 @@ storiesOf('module.Calendar.week', module)
     return (
       <div style={{ height: 600 }}>
         <Calendar
-          defaultView="week"
+          defaultView={Calendar.Views.WEEK}
           selectable
           timeslots={6}
           step={5}
@@ -251,7 +251,7 @@ storiesOf('module.Calendar.week', module)
     return (
       <div style={{ height: 600 }}>
         <Calendar
-          defaultView="week"
+          defaultView={Calendar.Views.WEEK}
           selectable
           timeslots={3}
           getNow={() => moment('9:30am', 'h:mma').toDate()}
@@ -537,7 +537,7 @@ storiesOf('module.Calendar.week', module)
     return (
       <div style={{ height: 600 }}>
         <Calendar
-          defaultView="week"
+          defaultView={Calendar.Views.WEEK}
           getNow={customNow}
           min={moment('12:00am', 'h:mma').toDate()}
           max={moment('11:59pm', 'h:mma').toDate()}
@@ -553,7 +553,7 @@ storiesOf('module.Calendar.week', module)
       <div style={{ height: 600 }}>
         <DragAndDropCalendar
           defaultDate={new Date()}
-          defaultView="week"
+          defaultView={Calendar.Views.WEEK}
           events={events}
           resizable
           onEventDrop={action('event dropped')}
@@ -567,7 +567,7 @@ storiesOf('module.Calendar.week', module)
       <div style={{ height: 600 }}>
         <DragAndDropCalendar
           defaultDate={new Date()}
-          defaultView="week"
+          defaultView={Calendar.Views.WEEK}
           events={events}
           resizable
           step={15}
@@ -583,7 +583,7 @@ storiesOf('module.Calendar.week', module)
       <div style={{ height: 600 }}>
         <DragAndDropCalendar
           defaultDate={new Date()}
-          defaultView="week"
+          defaultView={Calendar.Views.WEEK}
           events={events}
           resizable
           showMultiDayTimes
@@ -620,7 +620,7 @@ storiesOf('module.Calendar.week', module)
         <DragAndDropCalendar
           components={components}
           defaultDate={new Date()}
-          defaultView="month"
+          defaultView={Calendar.Views.MONTH}
           events={events}
           resizable
           showMultiDayTimes

--- a/stories/customComponents.js
+++ b/stories/customComponents.js
@@ -1,0 +1,49 @@
+import React from 'react'
+import { action } from '@storybook/react'
+
+const customComponents = {
+  dateCellWrapper: dateCellWrapperProps => {
+    // Show 'click me' text in arbitrary places by using the range prop
+    const hasAlert = dateCellWrapperProps.range
+      ? dateCellWrapperProps.range.some(date => {
+          return date.getDate() % 12 === 0
+        })
+      : false
+
+    const style = {
+      display: 'flex',
+      flex: 1,
+      borderLeft: '1px solid #DDD',
+      backgroundColor: hasAlert ? '#f5f5dc' : '#fff',
+    }
+    return (
+      <div style={style}>
+        {hasAlert && (
+          <a onClick={action('custom dateCellWrapper component clicked')}>
+            Click me
+          </a>
+        )}
+        {dateCellWrapperProps.children}
+      </div>
+    )
+  },
+  dayWrapper: dayWrapperProps => {
+    // Show different styles at arbitrary time
+    const hasCustomInfo = dayWrapperProps.value
+      ? dayWrapperProps.value.getHours() === 4
+      : false
+    const style = {
+      display: 'flex',
+      flex: 1,
+      backgroundColor: hasCustomInfo ? '#f5f5dc' : '#fff',
+    }
+    return (
+      <div style={style}>
+        {hasCustomInfo && 'Custom Day Wrapper'}
+        {dayWrapperProps.children}
+      </div>
+    )
+  },
+}
+
+export default customComponents


### PR DESCRIPTION
When testing out the dnd addon I found this note in a comment in `withDragAndDrop.js`: 

```
 * Note: you cannot use custom `EventWrapper`, `DayWrapper` or `DateCellWrapper`
 * components when using this HOC as they are overwritten here.
```

This was a huge bummer for us because we are wanting to use custom `DayWrapper` or `DateCellWrapper` components for contextual styling on day and date cells while also using drag and drop. 

With this PR I took a stab at adding support for custom `DayWrapper` and `DateCellWrapper` components. I reviewed the discussion on #716 (initial implementation) to make sure I wasn't missing why this wouldn't be possible. 

- `DropWrapper` now receives the `components` prop. It will still use the default `BackgroundWrapper` if no custom `dayWrapper` or `dateCellWrapper` component is provided
- Added a few stories showing custom `dayWrapper` and `dateCellWrapper` (both for dnd and non-dnd)
- Cleaned up some code in `stories` and `examples` for consistency
