### PR TITLE
Option resourceHeaderPropGetter

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -500,7 +500,7 @@ class Calendar extends React.Component {
 
     /**
      * Optionally provide a function that returns an object of className or style props
-     * to be applied to the the resource header.
+     * to be applied to the resource header.
      *
      * ```js
      * (resource: Object) => { className?: string, style?: Object }

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -499,6 +499,16 @@ class Calendar extends React.Component {
     dayPropGetter: PropTypes.func,
 
     /**
+     * Optionally provide a function that returns an object of className or style props
+     * to be applied to the the resource header.
+     *
+     * ```js
+     * (resource: Object) => { className?: string, style?: Object }
+     * ```
+     */
+    resourceHeaderPropGetter: PropTypes.func,
+
+    /**
      * Support to show multi-day events with specific start and end times in the
      * main time grid (rather than in the all day header).
      *

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -29,6 +29,7 @@ export default class TimeGrid extends Component {
     scrollToTime: PropTypes.instanceOf(Date),
     eventPropGetter: PropTypes.func,
     dayPropGetter: PropTypes.func,
+    resourceHeaderPropGetter: PropTypes.func,
     dayFormat: dateFormat,
     showMultiDayTimes: PropTypes.bool,
     culture: PropTypes.string,
@@ -264,6 +265,7 @@ export default class TimeGrid extends Component {
           resourceAccessor={this.props.resourceAccessor}
           resourceIdAccessor={this.props.resourceIdAccessor}
           resourceTitleAccessor={this.props.resourceTitleAccessor}
+          resourceHeaderPropGetter={this.props.resourceHeaderPropGetter}
           isOverflowing={this.state.isOverflowing}
           dayPropGetter={this.props.dayPropGetter}
           eventPropGetter={eventPropGetter}

--- a/src/TimeGridHeader.js
+++ b/src/TimeGridHeader.js
@@ -22,6 +22,7 @@ class TimeGridHeader extends React.Component {
     dayFormat: dateFormat,
     eventPropGetter: PropTypes.func,
     dayPropGetter: PropTypes.func,
+    resourceHeaderPropGetter: PropTypes.func,
     culture: PropTypes.string,
 
     rtl: PropTypes.bool,
@@ -62,16 +63,24 @@ class TimeGridHeader extends React.Component {
   }
 
   renderHeaderResources(range, resources) {
-    const { resourceTitleAccessor, getNow } = this.props
+    const {
+      resourceHeaderPropGetter,
+      resourceTitleAccessor,
+      getNow,
+    } = this.props
     const today = getNow()
 
     return range.map((date, i) => {
       return resources.map((resource, j) => {
+        const { className, style } =
+          (resourceHeaderPropGetter && resourceHeaderPropGetter(resource)) || {}
         return (
           <div
             key={`${i}-${j}`}
+            style={style}
             className={cn(
               'rbc-header',
+              className,
               dates.eq(date, today, 'day') && 'rbc-today'
             )}
           >


### PR DESCRIPTION
Added support for an option `resourceHeaderPropGetter` to enable custom styles on the resource headers. My use case was to categorize the resources into "resource groups" with colors.