### PR TITLE
Pass Events to DateHeader Component

### DIFF
--- a/src/Month.js
+++ b/src/Month.js
@@ -209,6 +209,7 @@ class MonthView extends React.Component {
 
   readerDateHeading = ({ date, className, ...props }) => {
     let {
+      events,
       date: currentDate,
       getDrilldownView,
       dateFormat,
@@ -233,6 +234,7 @@ class MonthView extends React.Component {
         <DateHeaderComponent
           label={label}
           date={date}
+          events={events.filter(evt => inRange(evt, date, date, this.props))}
           drilldownView={drilldownView}
           isOffRange={isOffRange}
           onDrillDown={e => this.handleHeadingClick(date, drilldownView, e)}

--- a/src/Month.js
+++ b/src/Month.js
@@ -193,7 +193,7 @@ class MonthView extends React.Component {
         allDayAccessor={allDayAccessor}
         eventPropGetter={eventPropGetter}
         dayPropGetter={dayPropGetter}
-        renderHeader={this.readerDateHeading}
+        renderHeader={this.renderDateHeading}
         renderForMeasure={needLimitMeasure}
         onShowMore={this.handleShowMore}
         onSelect={this.handleSelectEvent}
@@ -207,7 +207,7 @@ class MonthView extends React.Component {
     )
   }
 
-  readerDateHeading = ({ date, className, ...props }) => {
+  renderDateHeading = ({ date, className, ...props }) => {
     let {
       events,
       date: currentDate,

--- a/src/Month.js
+++ b/src/Month.js
@@ -221,6 +221,14 @@ class MonthView extends React.Component {
     let drilldownView = getDrilldownView(date)
     let label = localizer.format(date, dateFormat, culture)
     let DateHeaderComponent = this.props.components.dateHeader || DateHeader
+    events = events.filter(evt =>
+      inRange(
+        evt,
+        dates.startOf(date, 'day'),
+        dates.endOf(date, 'day'),
+        this.props
+      )
+    )
 
     return (
       <div
@@ -234,7 +242,7 @@ class MonthView extends React.Component {
         <DateHeaderComponent
           label={label}
           date={date}
-          events={events.filter(evt => inRange(evt, date, date, this.props))}
+          events={events}
           drilldownView={drilldownView}
           isOffRange={isOffRange}
           onDrillDown={e => this.handleHeadingClick(date, drilldownView, e)}


### PR DESCRIPTION
**Do you want to request a *feature* or report a *bug*?**

Feature

**What's the current behavior?**

The `DateHeader` component is aware of it's own `date`, but it is not aware of the events occurring on that `date`.

**What's the expected behavior?**

I would like to pass the events corresponding to the `date` of the `DateHeader` so the `DateHeader` is able to **apply styles based on the events of that day**.

This use case has arisen from the following requirement: "When a day has at least 1 event, the date header should be **bold**."

---

Let me know what you think, and thank you for considering my feature request.