### PR TITLE
Add timeGutterHeaderComponent

### DIFF
--- a/examples/demos/customView.js
+++ b/examples/demos/customView.js
@@ -52,9 +52,6 @@ let CustomView = () => (
     defaultView="week"
     defaultDate={new Date(2015, 3, 1)}
     views={{ month: true, week: MyWeek }}
-    components={{
-      timeGutterHeader: <p>Custom gutter text</p>,
-    }}
   />
 )
 

--- a/examples/demos/customView.js
+++ b/examples/demos/customView.js
@@ -52,6 +52,9 @@ let CustomView = () => (
     defaultView="week"
     defaultDate={new Date(2015, 3, 1)}
     views={{ month: true, week: MyWeek }}
+    components={{
+      timeGutterHeader: <p>Custom gutter text</p>,
+    }}
   />
 )
 

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -646,6 +646,7 @@ class Calendar extends React.Component {
       eventWrapper: elementType,
       dayWrapper: elementType,
       dateCellWrapper: elementType,
+      timeGutterHeader: elementType,
 
       toolbar: elementType,
 

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -272,6 +272,7 @@ export default class TimeGrid extends Component {
           eventComponent={components.event}
           eventWrapperComponent={components.eventWrapper}
           dateCellWrapperComponent={components.dateCellWrapper}
+          timeGutterHeaderComponent={components.timeGutterHeader}
           onSelectSlot={this.handleSelectAllDaySlot}
           onSelectEvent={this.handleSelectAlldayEvent}
           onDoubleClickEvent={this.props.onDoubleClickEvent}

--- a/src/TimeGridHeader.js
+++ b/src/TimeGridHeader.js
@@ -149,7 +149,7 @@ class TimeGridHeader extends React.Component {
       eventComponent,
       dateCellWrapperComponent,
       eventWrapperComponent,
-      timeGutterHeaderComponent,
+      timeGutterHeaderComponent: TimeGutterHeader,
     } = this.props
 
     let style = {}
@@ -164,7 +164,7 @@ class TimeGridHeader extends React.Component {
         className={cn('rbc-time-header', isOverflowing && 'rbc-overflowing')}
       >
         <div className="rbc-label rbc-time-header-gutter" style={{ width }}>
-          {timeGutterHeaderComponent}
+          {TimeGutterHeader && <TimeGutterHeader />}
         </div>
 
         <div className="rbc-time-header-content">

--- a/src/TimeGridHeader.js
+++ b/src/TimeGridHeader.js
@@ -45,6 +45,7 @@ class TimeGridHeader extends React.Component {
     eventComponent: elementType,
     eventWrapperComponent: elementType.isRequired,
     dateCellWrapperComponent: elementType,
+    timeGutterHeaderComponent: elementType,
 
     onSelectSlot: PropTypes.func,
     onSelectEvent: PropTypes.func,
@@ -148,6 +149,7 @@ class TimeGridHeader extends React.Component {
       eventComponent,
       dateCellWrapperComponent,
       eventWrapperComponent,
+      timeGutterHeaderComponent,
     } = this.props
 
     let style = {}
@@ -161,7 +163,9 @@ class TimeGridHeader extends React.Component {
         style={style}
         className={cn('rbc-time-header', isOverflowing && 'rbc-overflowing')}
       >
-        <div className="rbc-label rbc-time-header-gutter" style={{ width }} />
+        <div className="rbc-label rbc-time-header-gutter" style={{ width }}>
+          {timeGutterHeaderComponent}
+        </div>
 
         <div className="rbc-time-header-content">
           <div className="rbc-row rbc-time-header-cell">

--- a/stories/Calendar.js
+++ b/stories/Calendar.js
@@ -561,3 +561,22 @@ storiesOf('module.Calendar.week', module)
       </div>
     )
   })
+  .add('custom time gutter header', () => {
+    const TimeGutter = () => <p>Custom gutter text</p>
+
+    return (
+      <div style={{ height: 600 }}>
+        <Calendar
+          popup
+          events={demoEvents}
+          onSelectEvent={action('event selected')}
+          defaultDate={new Date(2015, 3, 1)}
+          defaultView="week"
+          views={['week', 'day']}
+          components={{
+            timeGutterHeader: TimeGutter,
+          }}
+        />
+      </div>
+    )
+  })


### PR DESCRIPTION
Hi

This change adds a new component option that gets inserted as the contents of the header of the time gutter in week and day views.

Closes #853

Added an example of using the component to "Custom View" in examples:

![image](https://user-images.githubusercontent.com/1503076/41345713-72596576-6ed2-11e8-899b-d098b81c1462.png)
