### PR TITLE
fix selecting events in chrome

### DIFF
--- a/src/Selection.js
+++ b/src/Selection.js
@@ -322,6 +322,10 @@ class Selection {
       top = Math.min(pageY, y),
       old = this.selecting
 
+    if (!old && !(w || h)) {
+      return
+    }
+
     this.selecting = true
     this._selectRect = {
       top,

--- a/src/Selection.js
+++ b/src/Selection.js
@@ -322,6 +322,8 @@ class Selection {
       top = Math.min(pageY, y),
       old = this.selecting
 
+    // Prevent emitting selectStart event until mouse is moved.
+    // in Chrome on Windows, mouseMove event may be fired just after mouseDown event.
     if (!old && !(w || h)) {
       return
     }


### PR DESCRIPTION
Fixes #630 #614 

The issue can be reproduced in Google Chrome on Windows (but not on macOS).
In this browser, mouseMove event is called after mouseDown without moving mouse cursor.
So this fixes not to emit SelectEvent until cursor moved from initial position.
