### PR TITLE
Add support for dragging to next or prev dates within view

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -715,6 +715,16 @@ class Calendar extends React.Component {
     getNow: () => new Date(),
   }
 
+  static childContextTypes = {
+    onNavigate: PropTypes.func,
+  }
+
+  getChildContext() {
+    return {
+      onNavigate: this.handleNavigate,
+    }
+  }
+
   getViews = () => {
     const views = this.props.views
 

--- a/src/addons/dragAndDrop/withDragAndDrop.js
+++ b/src/addons/dragAndDrop/withDragAndDrop.js
@@ -63,6 +63,7 @@ export default function withDragAndDrop(
     static propTypes = {
       onEventDrop: PropTypes.func,
       onEventResize: PropTypes.func,
+      onNavigate: PropTypes.func,
       startAccessor: accessor,
       endAccessor: accessor,
       allDayAccessor: accessor,
@@ -92,6 +93,7 @@ export default function withDragAndDrop(
     static childContextTypes = {
       onEventDrop: PropTypes.func,
       onEventResize: PropTypes.func,
+      onNavigate: PropTypes.func,
       components: PropTypes.object,
       startAccessor: accessor,
       endAccessor: accessor,
@@ -104,6 +106,7 @@ export default function withDragAndDrop(
       return {
         onEventDrop: this.props.onEventDrop,
         onEventResize: this.props.onEventResize,
+        onNavigate: this.props.onNavigate,
         components: this.props.components,
         startAccessor: this.props.startAccessor,
         endAccessor: this.props.endAccessor,
@@ -136,6 +139,11 @@ export default function withDragAndDrop(
 
       if (isDragging !== this.state.isDragging) {
         setTimeout(() => this.setState({ isDragging }))
+      }
+
+      // Had to add this to support drag across next/prev
+      if (isDragging && this.monitor.didDrop()) {
+        setTimeout(() => this.setState({ isDragging: false }))
       }
     }
 

--- a/stories/Calendar.js
+++ b/stories/Calendar.js
@@ -674,3 +674,18 @@ storiesOf('module.Calendar.week', module)
       </div>
     )
   })
+  .add('drag to next/previous', () => {
+    return (
+      <div style={{ height: 600 }}>
+        <DragAndDropCalendar
+          defaultDate={new Date()}
+          defaultView="month"
+          events={events}
+          resizable
+          onEventDrop={action('event dropped')}
+          onEventResize={action('event resized')}
+          onNavigate={action('dragged to next/prev')}
+        />
+      </div>
+    )
+  })


### PR DESCRIPTION
This is an implementation for #887. I took the approach of turning the left and right edges of the month and week views as the previous and next drag targets. Hovering over these targets for at least 1s will initiate the next or previous `onNavigate`.

<img width="1080" alt="month" src="https://user-images.githubusercontent.com/549/42352186-b47f8eb0-806d-11e8-831f-5f569e8fd7a4.png">

<img width="1082" alt="week" src="https://user-images.githubusercontent.com/549/42352191-b8c65ad0-806d-11e8-9e0e-e9c88328dbe5.png">

For the most part, this copies what GCal does minus the animation and navigating multiple months/weeks by continuing to hover over the targets. I'd like to implement these two as well, but wanted to get early feedback on what y'all think about this approach.