### PR TITLE
Fix rtl prop has to be passed to the DateContentRow

### DIFF
--- a/src/Month.js
+++ b/src/Month.js
@@ -203,6 +203,7 @@ class MonthView extends React.Component {
         eventWrapperComponent={components.eventWrapper}
         dateCellWrapperComponent={components.dateCellWrapper}
         longPressThreshold={longPressThreshold}
+        rtl={this.props.rtl}
       />
     )
   }


### PR DESCRIPTION
I have made [jalali version of this component](https://github.com/fingerpich/jalali-react-big-calendar) and I have this problem to make it rtl.