### PR TITLE
Day layout bugfix

### DIFF
--- a/src/utils/DayEventLayout.js
+++ b/src/utils/DayEventLayout.js
@@ -94,10 +94,10 @@ function onSameRow(a, b, minimumStartDifference) {
   return (
     // Occupies the same start slot.
     Math.abs(b.start - a.start) < minimumStartDifference ||
-    // b's start slot overlaps with b's end slot.
-    (b.start > a.start && b.start < a.end) ||
     // b's start slot overlaps with a's end slot.
-    (b.start > a.start && b.start < a.end)
+    (b.start > a.start && b.start < a.end) ||
+    // a's start slot overlaps with b's end slot.
+    (a.start > b.start && a.start < b.end)
   )
 }
 

--- a/src/utils/DayEventLayout.js
+++ b/src/utils/DayEventLayout.js
@@ -94,7 +94,9 @@ function onSameRow(a, b, minimumStartDifference) {
   return (
     // Occupies the same start slot.
     Math.abs(b.start - a.start) < minimumStartDifference ||
-    // A's start slot overlaps with b's end slot.
+    // b's start slot overlaps with b's end slot.
+    (b.start > a.start && b.start < a.end) ||
+    // b's start slot overlaps with a's end slot.
     (b.start > a.start && b.start < a.end)
   )
 }


### PR DESCRIPTION
I think I've found a fix for #899. This allows for more events to be classified as 'leaves' instead of 'rows' in the day layout algorithm, which I think was the intended approach. @tobiasandersen sorry I keep bugging you about this. Hoping this is the fix. 

Before:

![before](https://i.imgur.com/ePyIAVb.png)

After:

![after](https://i.imgur.com/Ui0jVco.png)