### PR TITLE
Exposed onSelectStart, onSelectEnd to views

### DIFF
--- a/src/Month.js
+++ b/src/Month.js
@@ -44,6 +44,8 @@ let propTypes = {
   selected: PropTypes.object,
   selectable: PropTypes.oneOf([true, false, 'ignoreEvents']),
   longPressThreshold: PropTypes.number,
+  onSelectEnd: PropTypes.func,
+  onSelectStart: PropTypes.func,
 
   onNavigate: PropTypes.func,
   onSelectSlot: PropTypes.func,
@@ -146,6 +148,8 @@ class MonthView extends React.Component {
       longPressThreshold,
       accessors,
       getters,
+      onSelectEnd,
+      onSelectStart,
     } = this.props
 
     const { needLimitMeasure, rowLimit } = this.state
@@ -167,6 +171,8 @@ class MonthView extends React.Component {
         maxRows={rowLimit}
         selected={selected}
         selectable={selectable}
+        onSelectEnd={onSelectEnd}
+        onSelectStart={onSelectStart}
         components={components}
         accessors={accessors}
         getters={getters}

--- a/src/TimeGridHeader.js
+++ b/src/TimeGridHeader.js
@@ -27,6 +27,8 @@ class TimeGridHeader extends React.Component {
     selected: PropTypes.object,
     selectable: PropTypes.oneOf([true, false, 'ignoreEvents']),
     longPressThreshold: PropTypes.number,
+    onSelectEnd: PropTypes.func,
+    onSelectStart: PropTypes.func,
 
     onSelectSlot: PropTypes.func,
     onSelectEvent: PropTypes.func,
@@ -117,6 +119,8 @@ class TimeGridHeader extends React.Component {
       localizer,
       accessors,
       components,
+      onSelectEnd,
+      onSelectStart,
     } = this.props
 
     const resourceId = accessors.resourceId(resource)
@@ -136,6 +140,8 @@ class TimeGridHeader extends React.Component {
         className="rbc-allday-cell"
         selectable={selectable}
         selected={this.props.selected}
+        onSelectEnd={onSelectEnd}
+        onSelectStart={onSelectStart}
         components={components}
         accessors={accessors}
         getters={getters}


### PR DESCRIPTION
We're trying to find a way to add a **line** on the view (**and some text** indicating the time they've clicked on, while the **mouse is down**, and it will look like this:

<img src="https://cl.ly/2P2P2j3L0d0v/Screen%252520Recording%2525202018-08-10%252520at%25252011.08%252520PM.gif" />

but we have no way of knowing when the selection started or ended.

Hopefully this code will help in such cases.