### PR TITLE
Now allowing the dragAndDrop addOn components to be overriden

### DIFF
--- a/src/addons/dragAndDrop/withDragAndDrop.js
+++ b/src/addons/dragAndDrop/withDragAndDrop.js
@@ -136,10 +136,10 @@ export default function withDragAndDrop(Calendar) {
       )
 
       props.components = {
-        ...components,
         eventWrapper: EventWrapper,
         eventContainerWrapper: EventContainerWrapper,
         weekWrapper: WeekWrapper,
+        ...components,
       }
 
       return <Calendar {...props} />


### PR DESCRIPTION
Hey there,

I don't see why you wouldn't allow i.e a custom `weekWrapper` component to be passed here.
I moved the components spread operator a bit further down, so that we can override it.