### PR TITLE
Feature/selection time indicator line

### DIFF
--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -89,16 +89,9 @@ class DayColumn extends React.Component {
         components &&
         components.beforeSelectIndicatorComponent != null
       ) {
+        const SelectIndicator = components.beforeSelectIndicatorComponent
         // if the user is about to start selecting but hasn't started dragging yet
-        selectionElement = React.cloneElement(
-          components.beforeSelectIndicatorComponent,
-          {
-            top,
-            height,
-            startDate,
-            endDate,
-          }
-        )
+        selectionElement = <SelectIndicator {...this.state} />
       } else {
         // the user has already started dragging/selecting a time slot
         selectionElement = (

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -77,6 +77,41 @@ class DayColumn extends React.Component {
     this.slotMetrics = this.slotMetrics.update(nextProps)
   }
 
+  renderSelection() {
+    const { selecting } = this.state
+    if (selecting) {
+      let { top, height, startDate, endDate, noMovementYet } = this.state
+      const { localizer, components } = this.props
+      let selectDates = { start: startDate, end: endDate }
+      let selectionElement
+      if (
+        noMovementYet &&
+        components &&
+        components.beforeSelectIndicatorComponent != null
+      ) {
+        // if the user is about to start selecting but hasn't started dragging yet
+        selectionElement = React.cloneElement(
+          components.beforeSelectIndicatorComponent,
+          {
+            top,
+            height,
+            startDate,
+            endDate,
+          }
+        )
+      } else {
+        // the user has already started dragging/selecting a time slot
+        selectionElement = (
+          <div className="rbc-slot-selection" style={{ top, height }}>
+            <span>{localizer.format(selectDates, 'selectRangeFormat')}</span>
+          </div>
+        )
+      }
+      return selectionElement
+    }
+    return null
+  }
+
   render() {
     const {
       max,
@@ -91,9 +126,7 @@ class DayColumn extends React.Component {
     } = this.props
 
     let { slotMetrics } = this
-    let { selecting, top, height, startDate, endDate } = this.state
-
-    let selectDates = { start: startDate, end: endDate }
+    let { selecting } = this.state
 
     const { className, style } = dayProp(max)
     const current = getNow()
@@ -131,11 +164,7 @@ class DayColumn extends React.Component {
           </div>
         </EventContainer>
 
-        {selecting && (
-          <div className="rbc-slot-selection" style={{ top, height }}>
-            <span>{localizer.format(selectDates, 'selectRangeFormat')}</span>
-          </div>
-        )}
+        {this.renderSelection()}
       </div>
     )
   }
@@ -160,7 +189,7 @@ class DayColumn extends React.Component {
       events,
       accessors,
       slotMetrics,
-      minimumStartDifference: Math.ceil((step * timeslots) / 2),
+      minimumStartDifference: Math.ceil(step * timeslots / 2),
     })
 
     return styledEvents.map(({ event, style }, idx) => {
@@ -226,7 +255,8 @@ class DayColumn extends React.Component {
       if (
         this.state.start !== state.start ||
         this.state.end !== state.end ||
-        this.state.selecting !== state.selecting
+        this.state.selecting !== state.selecting ||
+        this.state.noMovementYet === true
       ) {
         this.setState(state)
       }
@@ -252,6 +282,7 @@ class DayColumn extends React.Component {
       return {
         ...selectRange,
         selecting: true,
+        noMovementYet: point.noMovementYet,
 
         top: `${selectRange.top}%`,
         height: `${selectRange.height}%`,
@@ -275,9 +306,17 @@ class DayColumn extends React.Component {
     selector.on('selectStart', maybeSelect)
 
     selector.on('beforeSelect', box => {
+      const didNotClickOnAnEvent = !isEvent(findDOMNode(this), box)
+      if (
+        didNotClickOnAnEvent &&
+        this.props.components &&
+        this.props.components.beforeSelectIndicatorComponent != null
+      ) {
+        maybeSelect({ ...box, noMovementYet: true })
+      }
       if (this.props.selectable !== 'ignoreEvents') return
 
-      return !isEvent(findDOMNode(this), box)
+      return didNotClickOnAnEvent
     })
 
     selector.on('click', box => selectorClicksHandler(box, 'click'))

--- a/src/EventEndingRow.js
+++ b/src/EventEndingRow.js
@@ -20,10 +20,7 @@ class EventEndingRow extends React.Component {
   }
 
   render() {
-    let {
-      segments,
-      slotMetrics: { slots },
-    } = this.props
+    let { segments, slotMetrics: { slots } } = this.props
     let rowSegments = eventLevels(segments).levels[0]
 
     let current = 1,

--- a/src/EventRow.js
+++ b/src/EventRow.js
@@ -12,11 +12,7 @@ class EventRow extends React.Component {
     ...EventRowMixin.defaultProps,
   }
   render() {
-    let {
-      segments,
-      slotMetrics: { slots },
-      className,
-    } = this.props
+    let { segments, slotMetrics: { slots }, className } = this.props
 
     let lastEnd = 1
 

--- a/src/EventRowMixin.js
+++ b/src/EventRowMixin.js
@@ -58,7 +58,7 @@ export default {
   },
 
   renderSpan(slots, len, key, content = ' ') {
-    let per = (Math.abs(len) / slots) * 100 + '%'
+    let per = Math.abs(len) / slots * 100 + '%'
 
     return (
       <div

--- a/src/TimeGridEvent.js
+++ b/src/TimeGridEvent.js
@@ -38,8 +38,8 @@ function TimeGridEvent(props) {
   return (
     <EventWrapper type="time" {...props}>
       <div
-        onClick={props.onClick}
-        onDoubleClick={props.onDoubleClick}
+        onClick={onClick}
+        onDoubleClick={onDoubleClick}
         style={{
           ...userProps.style,
           top: `${top}%`,

--- a/src/Toolbar.js
+++ b/src/Toolbar.js
@@ -14,10 +14,7 @@ class Toolbar extends React.Component {
   }
 
   render() {
-    let {
-      localizer: { messages },
-      label,
-    } = this.props
+    let { localizer: { messages }, label } = this.props
 
     return (
       <div className="rbc-toolbar">

--- a/src/utils/TimeSlots.js
+++ b/src/utils/TimeSlots.js
@@ -104,7 +104,7 @@ export function getSlotMetrics({ min: start, max: end, step, timeslots }) {
       if (dates.lt(date, start, 'minutes')) return slots[0]
 
       const diffMins = dates.diff(start, date, 'minutes')
-      return slots[(diffMins - (diffMins % step)) / step + offset]
+      return slots[(diffMins - diffMins % step) / step + offset]
     },
 
     startsBeforeDay(date) {
@@ -129,11 +129,11 @@ export function getSlotMetrics({ min: start, max: end, step, timeslots }) {
 
       const rangeStartMin = positionFromDate(rangeStart)
       const rangeEndMin = positionFromDate(rangeEnd)
-      const top = (rangeStartMin / totalMin) * 100
+      const top = rangeStartMin / totalMin * 100
 
       return {
         top,
-        height: (rangeEndMin / totalMin) * 100 - top,
+        height: rangeEndMin / totalMin * 100 - top,
         start: positionFromDate(rangeStart),
         startDate: rangeStart,
         end: positionFromDate(rangeEnd),


### PR DESCRIPTION
Allows to specify a component (amongst the other components) that will only get rendered, after the user clicks, but before they start dragging.

Example:

```
components={{
    beforeSelectIndicatorComponent: (selectionProps) => <BigCalendarPreSelectIndicator {...selectionProps} />,
}}
```

Now I can do this after clicking:
<img src="https://cl.ly/091e361y0N2L/Screen%20Recording%202018-08-14%20at%2010.40%20PM.gif" />

See the dashed line and the time tool tip before dragging?