### PR TITLE
This fixes event clicks/double clicks

### DIFF
--- a/src/TimeGridEvent.js
+++ b/src/TimeGridEvent.js
@@ -36,6 +36,8 @@ function TimeGridEvent(props) {
   return (
     <EventWrapper type="time" {...props}>
       <div
+        onClick={props.onClick}
+        onDoubleClick={props.onDoubleClick}
         style={{
           ...userProps.style,
           top: `${top}%`,


### PR DESCRIPTION
Currently, event clicks can't be clicked on the master branch, because the onClick event is passed on a react component (**NoopWrapper**) and not a Dom element

https://github.com/intljusticemission/react-big-calendar/blob/master/src/DayColumn.js#L198

This PR propagates the onClick and onDoubleClick to the containing div element, so that clicks on events work again.