### PR TITLE
No longer duplicating events while dragging/resizing (with css)

### DIFF
--- a/src/TimeGridEvent.js
+++ b/src/TimeGridEvent.js
@@ -38,8 +38,8 @@ function TimeGridEvent(props) {
   return (
     <EventWrapper type="time" {...props}>
       <div
-        onClick={props.onClick}
-        onDoubleClick={props.onDoubleClick}
+        onClick={onClick}
+        onDoubleClick={onDoubleClick}
         style={{
           ...userProps.style,
           top: `${top}%`,

--- a/src/addons/dragAndDrop/EventWrapper.js
+++ b/src/addons/dragAndDrop/EventWrapper.js
@@ -3,6 +3,7 @@ import React from 'react'
 import cn from 'classnames'
 import { accessor } from '../../utils/propTypes'
 import { accessor as get } from '../../utils/accessors'
+import { isSameEvent } from '../../utils/helpers'
 
 class EventWrapper extends React.Component {
   static contextTypes = {
@@ -68,46 +69,51 @@ class EventWrapper extends React.Component {
   }
 
   render() {
-    let { children, event, type, continuesPrior, continuesAfter } = this.props
+    const { event, type, continuesPrior, continuesAfter } = this.props
+
+    let { children } = this.props
 
     if (event.__isPreview)
       return React.cloneElement(children, {
         className: cn(children.props.className, 'rbc-addons-dnd-drag-preview'),
       })
 
-    let { draggableAccessor, resizableAccessor } = this.context
+    const { draggableAccessor, resizableAccessor, draggable } = this.context
 
-    let isDraggable = draggableAccessor ? !!get(event, draggableAccessor) : true
+    const isDraggable = draggableAccessor
+      ? !!get(event, draggableAccessor)
+      : true
 
     /* Event is not draggable, no need to wrap it */
     if (!isDraggable) {
       return children
     }
 
-    let StartAnchor = null,
-      EndAnchor = null
+    let StartAnchor = null
+    let EndAnchor = null
 
     /*
-     * The resizability of events depends on whether they are
-     * allDay events and how they are displayed.
-     *
-     * 1. If the event is being shown in an event row (because
-     * it is an allDay event shown in the header row or because as
-     * in month view the view is showing all events as rows) then we
-     * allow east-west resizing.
-     *
-     * 2. Otherwise the event is being displayed
-     * normally, we can drag it north-south to resize the times.
-     *
-     * See `DropWrappers` for handling of the drop of such events.
-     *
-     * Notwithstanding the above, we never show drag anchors for
-     * events which continue beyond current component. This happens
-     * in the middle of events when showMultiDay is true, and to
-     * events at the edges of the calendar's min/max location.
-     */
-
-    let isResizable = resizableAccessor ? !!get(event, resizableAccessor) : true
+ * The resizability of events depends on whether they are
+ * allDay events and how they are displayed.
+ *
+ * 1. If the event is being shown in an event row (because
+ * it is an allDay event shown in the header row or because as
+ * in month view the view is showing all events as rows) then we
+ * allow east-west resizing.
+ *
+ * 2. Otherwise the event is being displayed
+ * normally, we can drag it north-south to resize the times.
+ *
+ * See `DropWrappers` for handling of the drop of such events.
+ *
+ * Notwithstanding the above, we never show drag anchors for
+ * events which continue beyond current component. This happens
+ * in the middle of events when showMultiDay is true, and to
+ * events at the edges of the calendar's min/max location.
+ */
+    const isResizable = resizableAccessor
+      ? !!get(event, resizableAccessor)
+      : true
 
     if (isResizable) {
       if (type === 'date') {
@@ -119,17 +125,18 @@ class EventWrapper extends React.Component {
       }
 
       /*
-      * props.children is the singular <Event> component.
-      * BigCalendar positions the Event abolutely and we
-      * need the anchors to be part of that positioning.
-      * So we insert the anchors inside the Event's children
-      * rather than wrap the Event here as the latter approach
-      * would lose the positioning.
-      */
-      children = React.cloneElement(children, {
+  * props.children is the singular <Event> component.
+  * BigCalendar positions the Event abolutely and we
+  * need the anchors to be part of that positioning.
+  * So we insert the anchors inside the Event's children
+  * rather than wrap the Event here as the latter approach
+  * would lose the positioning.
+  */
+      const newProps = {
         onMouseDown: this.handleStartDragging,
         onTouchStart: this.handleStartDragging,
         // replace original event child with anchor-embellished child
+
         children: (
           <div className="rbc-addons-dnd-resizable">
             {StartAnchor}
@@ -137,7 +144,20 @@ class EventWrapper extends React.Component {
             {EndAnchor}
           </div>
         ),
-      })
+      }
+
+      if (
+        draggable.dragAndDropAction.interacting && // if an event is being dragged right now
+        isSameEvent(draggable.dragAndDropAction.event, event) // and it's the current event
+      ) {
+        // add a new class to it
+        newProps.className = cn(
+          children.props.className,
+          'rbc-addons-dnd-drag-dragged-event'
+        )
+      }
+
+      children = React.cloneElement(children, newProps)
     }
 
     return children

--- a/src/addons/dragAndDrop/EventWrapper.js
+++ b/src/addons/dragAndDrop/EventWrapper.js
@@ -153,7 +153,7 @@ class EventWrapper extends React.Component {
         // add a new class to it
         newProps.className = cn(
           children.props.className,
-          'rbc-addons-dnd-drag-dragged-event'
+          'rbc-addons-dnd-dragged-event'
         )
       }
 

--- a/src/addons/dragAndDrop/styles.less
+++ b/src/addons/dragAndDrop/styles.less
@@ -11,11 +11,6 @@
     right: 0;
   }
 
-  .rbc-addons-dnd-dragging {
-    opacity: .25;
-    touch-action: manipulation;
-  }
-
 
   .rbc-addons-dnd-over {
     background-color: rgba(
@@ -34,13 +29,14 @@
     }
   }
  
-  .rbc-time-view .rbc-addons-dnd-drag-dragged-event {
+  .rbc-time-view .rbc-addons-dnd-dragged-event {
     opacity: 0;
+    touch-action: manipulation;
   }
 
-  // &.rbc-addons-dnd-is-dragging .rbc-event:not(.rbc-addons-dnd-dragging):not(.rbc-addons-dnd-drag-preview) {
-  //   opacity: .50;
-  // }
+  &.rbc-addons-dnd-is-dragging .rbc-event:not(.rbc-addons-dnd-dragged-event):not(.rbc-addons-dnd-drag-preview) {
+    opacity: .50;
+  }
 
   .rbc-addons-dnd-resizable {
     position: relative;

--- a/src/addons/dragAndDrop/styles.less
+++ b/src/addons/dragAndDrop/styles.less
@@ -31,7 +31,6 @@
  
   .rbc-time-view .rbc-addons-dnd-dragged-event {
     opacity: 0;
-    touch-action: manipulation;
   }
 
   &.rbc-addons-dnd-is-dragging .rbc-event:not(.rbc-addons-dnd-dragged-event):not(.rbc-addons-dnd-drag-preview) {

--- a/src/addons/dragAndDrop/styles.less
+++ b/src/addons/dragAndDrop/styles.less
@@ -33,10 +33,14 @@
       .rbc-addons-dnd-resize-ns-icon, .rbc-addons-dnd-resize-ew-icon { display: block; }
     }
   }
-
-  &.rbc-addons-dnd-is-dragging .rbc-event:not(.rbc-addons-dnd-dragging):not(.rbc-addons-dnd-drag-preview) {
-    opacity: .50;
+ 
+  .rbc-time-view .rbc-addons-dnd-drag-dragged-event {
+    opacity: 0;
   }
+
+  // &.rbc-addons-dnd-is-dragging .rbc-event:not(.rbc-addons-dnd-dragging):not(.rbc-addons-dnd-drag-preview) {
+  //   opacity: .50;
+  // }
 
   .rbc-addons-dnd-resizable {
     position: relative;

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -19,3 +19,21 @@ export function isFirstFocusedRender(component) {
     (component.state.focused && (component._firstFocus = true))
   )
 }
+export function isSameEvent(event1, event2) {
+  if (event1 && event2) {
+    // if they both exist
+    if (event1.id != null && event2.id != null) {
+      // and they have an id
+      // they are equal if they have the same id
+      return event1.id === event2.id
+    }
+    // if no id exists
+    return (
+      // they are equal if they have
+      event1.start === event2.start && // the same start time
+      event1.end === event2.end && // the same end time
+      event1.calendar_id === event2.calendar_id // and the same end calendar id
+    )
+  }
+  return !event1 && !event2
+}


### PR DESCRIPTION
Here's a set of fixes to the dnd add-on.
The most important change is this:

Expected behaviour:
<img src="https://cl.ly/0D07201A3K28/Screen%252520Recording%2525202018-08-17%252520at%25252010.42%252520PM.gif" />

Actual behaviour:

<img src="https://cl.ly/2d3e0m1e233U/Screen%252520Recording%2525202018-08-17%252520at%25252011.21%252520PM.gif" />

This PR fixes that by creating a subset of events (that doesn't contain the updatee - the event that is being dragged).

That happens for both move and resize actions.