### PR TITLE
Fix totalMin calculation in TimeSlots.

### DIFF
--- a/src/utils/TimeSlots.js
+++ b/src/utils/TimeSlots.js
@@ -11,7 +11,8 @@ const getKey = (min, max, step, slots) =>
 export function getSlotMetrics({ min: start, max: end, step, timeslots }) {
   const key = getKey(start, end, step, timeslots)
 
-  const totalMin = dates.diff(start, end, 'minutes') + getDstOffset(start, end)
+  const totalMin =
+    1 + dates.diff(start, end, 'minutes') + getDstOffset(start, end)
   const minutesFromMidnight = dates.diff(
     dates.startOf(start, 'day'),
     start,


### PR DESCRIPTION
This PR fixes the calculation of the percentage `top` offsets for Events in the Day view (probably the other views too).  The `dates.diff` method doesn't round, so if you display 00:00:00-23:59:59, `totalMin` will be computed as `1439` instead of `1440`.  An Event at 12:00:00 should have `top: 50%` but with the old computation it had `top: 50.0347%` (off by `1.2px` at `4000px` height).  Similarly, an Event at 23:00 will be off by `2.66px`.

You may not have noticed that it was incorrect since it only starts to deviate with large Calendars.  Calendars in my app are sometimes `8000px` or larger, which is how I noticed the gaps.

To demonstrate for yourself that the previous calculation was wrong, open [an example](http://intljusticemission.github.io/react-big-calendar/examples/index.html) and set the height of the `.rbc-calendar` to a large number like `4000px`.  As you scroll down you'll see the events are more and more incorrectly placed.
