### PR TITLE
Adding tabbable events

### DIFF
--- a/src/EventCell.js
+++ b/src/EventCell.js
@@ -70,7 +70,7 @@ class EventCell extends React.Component {
 
     return (
       <EventWrapper {...this.props} type="date">
-        <div
+        <button
           {...props}
           style={{ ...userProps.style, ...style }}
           className={cn('rbc-event', className, userProps.className, {
@@ -83,7 +83,7 @@ class EventCell extends React.Component {
           onDoubleClick={e => onDoubleClick && onDoubleClick(event, e)}
         >
           {typeof children === 'function' ? children(content) : content}
-        </div>
+        </button>
       </EventWrapper>
     )
   }

--- a/src/less/event.less
+++ b/src/less/event.less
@@ -1,6 +1,6 @@
 @import './variables.less';
 
-.rbc-event {
+button.rbc-event {
   padding: @event-padding;
   background-color: @event-bg;
   border-radius: @event-border-radius;

--- a/src/less/event.less
+++ b/src/less/event.less
@@ -3,9 +3,12 @@
 .rbc-event {
   padding: @event-padding;
   background-color: @event-bg;
+  border: 0;
   border-radius: @event-border-radius;
   color: @event-color;
   cursor: pointer;
+  width: 100%;
+  text-align: left;
 
   .rbc-slot-selecting & {
     cursor: inherit;
@@ -14,6 +17,10 @@
 
   &.rbc-selected {
     background-color: darken(@event-bg, 10%);
+  }
+
+  &:focus {
+    border: 2px solid red;
   }
 }
 
@@ -44,4 +51,3 @@
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
 }
-

--- a/src/less/event.less
+++ b/src/less/event.less
@@ -3,7 +3,6 @@
 .rbc-event {
   padding: @event-padding;
   background-color: @event-bg;
-  border: 0;
   border-radius: @event-border-radius;
   color: @event-color;
   cursor: pointer;
@@ -20,7 +19,7 @@
   }
 
   &:focus {
-    border: 2px solid red;
+    outline: 5px auto @event-outline;
   }
 }
 

--- a/src/less/event.less
+++ b/src/less/event.less
@@ -1,6 +1,9 @@
 @import './variables.less';
 
-button.rbc-event {
+.rbc-event {
+  border: none;
+  box-shadow: none;
+  margin: 0;
   padding: @event-padding;
   background-color: @event-bg;
   border-radius: @event-border-radius;

--- a/src/less/reset.less
+++ b/src/less/reset.less
@@ -4,6 +4,14 @@
   margin: 0;
 }
 
+button {
+  padding: 0;
+  margin: 0;
+  border: none;
+  box-shadow: none;
+  background: none;
+}
+
 button.rbc-btn {
   overflow: visible;
   text-transform: none;

--- a/src/less/reset.less
+++ b/src/less/reset.less
@@ -4,14 +4,6 @@
   margin: 0;
 }
 
-button {
-  padding: 0;
-  margin: 0;
-  border: none;
-  box-shadow: none;
-  background: none;
-}
-
 button.rbc-btn {
   overflow: visible;
   text-transform: none;
@@ -26,4 +18,12 @@ button[disabled].rbc-btn {
 button.rbc-input::-moz-focus-inner {
   border: 0;
   padding: 0;
+}
+
+button.rbc-event {
+  padding: 0;
+  margin: 0;
+  border: none;
+  box-shadow: none;
+  background: none;
 }

--- a/src/less/reset.less
+++ b/src/less/reset.less
@@ -19,11 +19,3 @@ button.rbc-input::-moz-focus-inner {
   border: 0;
   padding: 0;
 }
-
-button.rbc-event {
-  padding: 0;
-  margin: 0;
-  border: none;
-  box-shadow: none;
-  background: none;
-}

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -16,6 +16,7 @@
 
 @event-bg: #3174ad;
 @event-border: darken(#3174ad, 10%);
+@event-outline: #3b99fc;
 @event-color: #fff;
 @event-border-radius: 5px;
 @event-padding: 2px 5px;


### PR DESCRIPTION
Switching EventWrapper content into `<button>` for accessibility purposes (navigation by tab).

![tabbable-events](https://user-images.githubusercontent.com/1758136/45301875-d8096080-b4df-11e8-90c2-8b4c8b0603b6.gif)
