### PR TITLE
Increase startup time of event dragging

### DIFF
--- a/src/addons/dragAndDrop/withDragAndDrop.js
+++ b/src/addons/dragAndDrop/withDragAndDrop.js
@@ -97,7 +97,7 @@ export default function withDragAndDrop(Calendar) {
         weekWrapper: WeekWrapper,
       })
 
-      this.state = {}
+      this.state = { interacting: false }
     }
 
     getChildContext() {
@@ -118,7 +118,7 @@ export default function withDragAndDrop(Calendar) {
     }
 
     handleInteractionStart = () => {
-      this.setState({ interacting: true })
+      if (this.state.interacting === false) this.setState({ interacting: true })
     }
 
     handleInteractionEnd = interactionInfo => {


### PR DESCRIPTION
If the state is checked in the handleInteractionStart method, subsequent calls of setState are prevented. This leads to faster initializations of the dragging animation.