### PR TITLE
fix: event resizing

### DIFF
--- a/src/addons/dragAndDrop/EventContainerWrapper.js
+++ b/src/addons/dragAndDrop/EventContainerWrapper.js
@@ -143,10 +143,9 @@ class EventContainerWrapper extends React.Component {
 
     selector.on('selectStart', () => this.context.draggable.onStart())
 
-    selector.on('select', point => {
-      const bounds = getBoundsForNode(node)
+    selector.on('select', () => {
+      if (!this.state.event) return
 
-      if (!this.state.event || !pointInColumn(bounds, point)) return
       this.handleInteractionEnd()
     })
 


### PR DESCRIPTION
Resizing an event towards another day currently leads to a somewhat buggy in-between visualization state.
If we do not perform the pointInColumn check at this point, everything works as expected.