### PR TITLE
avoid unnecessary setState to make dnd faster

### DIFF
--- a/src/addons/dragAndDrop/withDragAndDrop.js
+++ b/src/addons/dragAndDrop/withDragAndDrop.js
@@ -118,7 +118,9 @@ export default function withDragAndDrop(Calendar) {
     }
 
     handleInteractionStart = () => {
-      this.setState({ interacting: true })
+      if (!this.state.interacting) {
+        this.setState({ interacting: true })
+      }
     }
 
     handleInteractionEnd = interactionInfo => {


### PR DESCRIPTION
currently when start dragging an event, the handleInteractionStart get triggered multiple times but only first setState is required. This MR add a if check to avoid unnecessary setState calls.

The speed change is noticeable for DnD in resource schedule with week view. 