### PR TITLE
Add zIndex to day column events

### DIFF
--- a/src/TimeGridEvent.js
+++ b/src/TimeGridEvent.js
@@ -25,7 +25,7 @@ function TimeGridEvent(props) {
 
   let userProps = getters.eventProp(event, start, end, selected)
 
-  let { height, top, width, xOffset } = style
+  let { height, top, width, xOffset, zIndex } = style
   const inner = [
     <div key="1" className="rbc-event-label">
       {label}
@@ -46,6 +46,7 @@ function TimeGridEvent(props) {
           height: `${height}%`,
           [isRtl ? 'right' : 'left']: `${Math.max(0, xOffset)}%`,
           width: `${width}%`,
+          zIndex: zIndex,
         }}
         title={
           tooltip

--- a/src/less/styles.less
+++ b/src/less/styles.less
@@ -78,7 +78,7 @@
   position: relative;
   user-select: none;
   -webkit-user-select: none;
-  z-index: 4;
+  z-index: 114;
 }
 
 .rbc-today {

--- a/src/less/time-column.less
+++ b/src/less/time-column.less
@@ -83,7 +83,7 @@
     left: 0;
     background-color: white;
     border-right: 1px solid @cell-border;
-    z-index: 10;
+    z-index: 120;
     margin-right: -1px;
   }
 

--- a/src/less/time-grid.less
+++ b/src/less/time-grid.less
@@ -2,7 +2,7 @@
 @import './time-column.less';
 
 .rbc-slot-selection {
-  z-index: 10;
+  z-index: 120;
   position: absolute;
   background-color: @time-selection-bg-color;
   color: @time-selection-color;
@@ -39,7 +39,7 @@
 
   .rbc-allday-events {
     position: relative;
-    z-index: 4;
+    z-index: 114;
   }
 
   .rbc-row {
@@ -123,7 +123,7 @@
 
 .rbc-current-time-indicator {
   position: absolute;
-  z-index: 3;
+  z-index: 113;
   left: 0;
   right: 0;
   height: 1px;

--- a/src/utils/DayEventLayout.js
+++ b/src/utils/DayEventLayout.js
@@ -193,6 +193,7 @@ function getStyledEvents({
       height: event.height,
       width: event.width,
       xOffset: event.xOffset,
+      zIndex: Math.floor(event.xOffset),
     },
   }))
 }

--- a/test/utils/DayEventLayout.test.js
+++ b/test/utils/DayEventLayout.test.js
@@ -12,12 +12,14 @@ describe('getStyledEvents', () => {
   describe('matrix', () => {
     function compare(title, events, expectedResults) {
       it(title, () => {
+        events.forEach((event, index) => (event.id = index))
         const styledEvents = getStyledEvents({
           events,
           accessors,
           slotMetrics,
           minimumStartDifference: 10,
         })
+        styledEvents.sort((a, b) => a.event.id - b.event.id)
         const results = styledEvents.map(result => ({
           width: Math.floor(result.style.width),
           xOffset: Math.floor(result.style.xOffset),
@@ -87,6 +89,38 @@ describe('getStyledEvents', () => {
           { width: 56, xOffset: 0 },
           { width: 56, xOffset: 33 },
           { width: 33, xOffset: 66 },
+        ],
+      ],
+      [
+        'complex events spanning multiple containers (issue #899)',
+        [
+          { start: d(8, 15), end: d(13, 15) },
+          { start: d(8, 45), end: d(14) },
+          { start: d(10, 45), end: d(17) },
+          { start: d(14), end: d(20) },
+          { start: d(15, 30), end: d(20, 30) },
+        ],
+        [
+          { width: 56, xOffset: 0 },
+          { width: 56, xOffset: 33 },
+          { width: 33, xOffset: 66 },
+          { width: 85, xOffset: 0 },
+          { width: 50, xOffset: 50 },
+        ],
+      ],
+      [
+        'latest events of a row overlapping with the following row',
+        [
+          { start: d(9, 30), end: d(15, 30) },
+          { start: d(9, 30), end: d(11, 30) },
+          { start: d(11), end: d(13) },
+          { start: d(12), end: d(13) },
+        ],
+        [
+          { width: 56, xOffset: 0 },
+          { width: 56, xOffset: 33 },
+          { width: 33, xOffset: 66 },
+          { width: 66, xOffset: 33 },
         ],
       ],
     ]


### PR DESCRIPTION
#### Do you want to request a _feature_ or report a _bug_?

A bug

#### What's the current behavior?

![calendar - wrong](https://user-images.githubusercontent.com/1941277/47006418-25f43280-d136-11e8-8dfd-87c4b626f9e3.png)

Events on the end of a row overlapping another row are hidden by the row behind them. See the small bit of event on the end of the pointer.

#### What's the expected behavior?

Event 2 should be visible.

![calendar - better](https://user-images.githubusercontent.com/1941277/47006890-453f8f80-d137-11e8-960c-2c0421f30ecb.png)

#### PR implementation notes

To solve this problem, Google Calendar set a zIndex corresponding to the number of the column the events belong to, starting from 4 and going up. In red the zIndex corresponding to the events below it.

![gcal](https://user-images.githubusercontent.com/1941277/47007402-6eaceb00-d138-11e8-9d6c-07efaffa2249.png)

I took the same approach, but as we don't compute columns across rows, I set a zIndex corresponding to the offset, 5 + xOffset. Having the leftmost event with a non-zero z-index will show users if they have a display bug sooner. Just setting the number in the row as a zIndex wouldn't work with the following example :

![calendar - 5](https://user-images.githubusercontent.com/1941277/47006973-76b85b00-d137-11e8-8a17-4b907b93606f.png)

I modified the zIndex given in the CSS file provided by the project but it may break the display of people using their own.

As a side note, the following example still don't work, but the way rows are computed would need to be rewritten and I don't have time right now : 

![calendar - 4](https://user-images.githubusercontent.com/1941277/47007055-abc4ad80-d137-11e8-8141-a7c9edd50f14.png)

