### PR TITLE
Remove extractText plugin to fix storybook

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -14,6 +14,6 @@ module.exports = function(config) {
         rules.less({ browsers }),
       ],
     },
-    plugins: [...config.plugins, plugins.extractText()],
+    plugins: [...config.plugins],
   }
 }


### PR DESCRIPTION
As I couldn't run Storybook, I made a workaround.