### PR TITLE
Fix misplacement of current time indicator

### DIFF
--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -84,6 +84,15 @@ class DayColumn extends React.Component {
     this.slotMetrics = this.slotMetrics.update(nextProps)
   }
 
+  componentDidUpdate(prevProps) {
+    if (prevProps.date.getTime() !== this.props.date.getTime()) {
+      if (this.props.isNow) {
+        this.positionTimeIndicator()
+        this.triggerTimeIndicatorUpdate()
+      }
+    }
+  }
+
   triggerTimeIndicatorUpdate() {
     // Update the position of the time indicator every minute
     this._timeIndicatorTimeout = window.setTimeout(() => {
@@ -188,7 +197,7 @@ class DayColumn extends React.Component {
       events,
       accessors,
       slotMetrics,
-      minimumStartDifference: Math.ceil(step * timeslots / 2),
+      minimumStartDifference: Math.ceil((step * timeslots) / 2),
     })
 
     return styledEvents.map(({ event, style }, idx) => {


### PR DESCRIPTION
After switching the weekly calendar towards the current week, the current time indicator is initially misplaced. By checking whether the date of the component changed in the componentDidUpdate cycle and then calling triggerTimeIndicatorUpdate, this issue can get addressed.