### PR TITLE
Fix onRangeChange not passing localizer

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -889,10 +889,11 @@ class Calendar extends React.Component {
   }
 
   handleRangeChange = (date, view) => {
-    let { onRangeChange } = this.props
+    let { onRangeChange, localizer } = this.props
+
     if (onRangeChange) {
       if (view.range) {
-        onRangeChange(view.range(date, {}))
+        onRangeChange(view.range(date, { localizer }))
       } else {
         warning(true, 'onRangeChange prop not supported for this view')
       }


### PR DESCRIPTION
Fixes #1042, the error isn't present on the examples until you add an `onRangeChange` prop. All that was required was passing the localizer through.