### PR TITLE
Fix elements position on TimeGrid if max prop is set

### DIFF
--- a/src/utils/TimeSlots.js
+++ b/src/utils/TimeSlots.js
@@ -105,7 +105,7 @@ export function getSlotMetrics({ min: start, max: end, step, timeslots }) {
       if (dates.lt(date, start, 'minutes')) return slots[0]
 
       const diffMins = dates.diff(start, date, 'minutes')
-      return slots[(diffMins - diffMins % step) / step + offset]
+      return slots[(diffMins - (diffMins % step)) / step + offset]
     },
 
     startsBeforeDay(date) {
@@ -130,11 +130,11 @@ export function getSlotMetrics({ min: start, max: end, step, timeslots }) {
 
       const rangeStartMin = positionFromDate(rangeStart)
       const rangeEndMin = positionFromDate(rangeEnd)
-      const top = rangeStartMin / totalMin * 100
+      const top = (rangeStartMin / (step * numSlots)) * 100
 
       return {
         top,
-        height: rangeEndMin / totalMin * 100 - top,
+        height: (rangeEndMin / (step * numSlots)) * 100 - top,
         start: positionFromDate(rangeStart),
         startDate: rangeStart,
         end: positionFromDate(rangeEnd),


### PR DESCRIPTION
Fixes #999, #1051

Calendar shows integer number of timeslot groups, therefore even if `max` prop is set to 23:00, it will still render area with 00:00 as highest border.