### PR TITLE
Fix today's time indicator in week view

### DIFF
--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -71,6 +71,14 @@ class DayColumn extends React.Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    if (prevProps.date.getTime() !== this.props.date.getTime()) {
+      if (this.props.isNow) {
+        this.positionTimeIndicator()
+      }
+    }
+  }
+
   componentWillUnmount() {
     this._teardownSelectable()
     window.clearTimeout(this._timeIndicatorTimeout)
@@ -188,7 +196,7 @@ class DayColumn extends React.Component {
       events,
       accessors,
       slotMetrics,
-      minimumStartDifference: Math.ceil(step * timeslots / 2),
+      minimumStartDifference: Math.ceil((step * timeslots) / 2),
     })
 
     return styledEvents.map(({ event, style }, idx) => {


### PR DESCRIPTION
When you navigate into weeks and come back to `today`, the time indicator position was reset to the very top of the column. To keep it accurate, we re-compute its position after the component did update.