### PR TITLE
fix: Examples not fully shown until first state change

### DIFF
--- a/examples/App.js
+++ b/examples/App.js
@@ -45,20 +45,26 @@ const EXAMPLES = {
   dnd: 'Addon: Drag and drop',
 }
 
+const DEFAULT_EXAMPLE = 'basic'
+
 class Example extends React.Component {
   constructor(...args) {
     super(...args)
 
-    const hash = (window.location.hash || '').slice(1)
-
     this.state = {
-      selected: EXAMPLES[hash] ? hash : 'basic',
+      selected: DEFAULT_EXAMPLE,
     }
   }
 
   select = selected => {
     this.setState({ selected })
   }
+
+  componentDidMount() {
+    const hash = (window.location.hash || '').slice(1)
+    this.select(hash || DEFAULT_EXAMPLE)
+  }
+
   render() {
     let selected = this.state.selected
     let Current = {
@@ -126,6 +132,7 @@ class Example extends React.Component {
                 <Dropdown.Menu>
                   {Object.entries(EXAMPLES).map(([key, title]) => (
                     <MenuItem
+                      active={this.state.selected === key}
                       key={key}
                       href={`#${key}`}
                       onClick={() => this.select(key)}


### PR DESCRIPTION
Previously sending someone to the example link like: https://intljusticemission.github.io/react-big-calendar/examples/index.html#cultures would not completely load the interface. (The culture drop down wasn't present until after menu selection)

I've moved the hash detection to componentDidMount() and used a set state to ensure we trigger a re-render.

To test select a non-default example and reload the page. Opening the menu and selecting the same value again should not cause any re-renders.