### PR TITLE
Fix bug with drag and drop on touch screens

### DIFF
--- a/src/addons/dragAndDrop/EventContainerWrapper.js
+++ b/src/addons/dragAndDrop/EventContainerWrapper.js
@@ -186,7 +186,6 @@ class EventContainerWrapper extends React.Component {
 
     if (!event) return children
 
-    const events = children.props.children
     const { start, end } = event
 
     let label
@@ -201,27 +200,25 @@ class EventContainerWrapper extends React.Component {
     if (startsBeforeDay && startsAfterDay) label = localizer.messages.allDay
     else label = localizer.format({ start, end }, format)
 
-    return React.cloneElement(children, {
-      children: (
-        <React.Fragment>
-          {events}
+    return (
+      <React.Fragment>
+        {children}
 
-          {event && (
-            <TimeGridEvent
-              event={event}
-              label={label}
-              className="rbc-addons-dnd-drag-preview"
-              style={{ top, height, width: 100 }}
-              getters={getters}
-              components={{ ...components, eventWrapper: NoopWrapper }}
-              accessors={{ ...accessors, ...dragAccessors }}
-              continuesEarlier={startsBeforeDay}
-              continuesLater={startsAfterDay}
-            />
-          )}
-        </React.Fragment>
-      ),
-    })
+        {event && (
+          <TimeGridEvent
+            event={event}
+            label={label}
+            className="rbc-addons-dnd-drag-preview"
+            style={{ top, height, width: 100 }}
+            getters={getters}
+            components={{ ...components, eventWrapper: NoopWrapper }}
+            accessors={{ ...accessors, ...dragAccessors }}
+            continuesEarlier={startsBeforeDay}
+            continuesLater={startsAfterDay}
+          />
+        )}
+      </React.Fragment>
+    )
   }
 }
 

--- a/src/addons/dragAndDrop/EventWrapper.js
+++ b/src/addons/dragAndDrop/EventWrapper.js
@@ -32,26 +32,83 @@ class EventWrapper extends React.Component {
   handleResizeUp = e => {
     if (e.button !== 0) return
     e.stopPropagation()
+
+    const lastNativeEvent = this.context.draggable.dragAndDropAction.nativeEvent
+    const nativeEvent = e.nativeEvent.type
+    const touchEndThenMouseDown =
+      lastNativeEvent === 'touchend' && nativeEvent === 'mousedown'
+    const { interacting } = this.context.draggable.dragAndDropAction
+
     this.context.draggable.onBeginAction(this.props.event, 'resize', 'UP')
+
+    if ((nativeEvent === 'touchend' && !interacting) || touchEndThenMouseDown) {
+      this.context.draggable.onEnd(null)
+    }
   }
   handleResizeDown = e => {
     if (e.button !== 0) return
     e.stopPropagation()
+
+    const lastNativeEvent = this.context.draggable.dragAndDropAction.nativeEvent
+    const nativeEvent = e.nativeEvent.type
+    const touchEndThenMouseDown =
+      lastNativeEvent === 'touchend' && nativeEvent === 'mousedown'
+    const { interacting } = this.context.draggable.dragAndDropAction
+
     this.context.draggable.onBeginAction(this.props.event, 'resize', 'DOWN')
+
+    if ((nativeEvent === 'touchend' && !interacting) || touchEndThenMouseDown) {
+      this.context.draggable.onEnd(null)
+    }
   }
   handleResizeLeft = e => {
     if (e.button !== 0) return
     e.stopPropagation()
+
+    const lastNativeEvent = this.context.draggable.dragAndDropAction.nativeEvent
+    const nativeEvent = e.nativeEvent.type
+    const touchEndThenMouseDown =
+      lastNativeEvent === 'touchend' && nativeEvent === 'mousedown'
+    const { interacting } = this.context.draggable.dragAndDropAction
+
     this.context.draggable.onBeginAction(this.props.event, 'resize', 'LEFT')
+
+    if ((nativeEvent === 'touchend' && !interacting) || touchEndThenMouseDown) {
+      this.context.draggable.onEnd(null)
+    }
   }
   handleResizeRight = e => {
     if (e.button !== 0) return
     e.stopPropagation()
+
+    const lastNativeEvent = this.context.draggable.dragAndDropAction.nativeEvent
+    const nativeEvent = e.nativeEvent.type
+    const touchEndThenMouseDown =
+      lastNativeEvent === 'touchend' && nativeEvent === 'mousedown'
+    const { interacting } = this.context.draggable.dragAndDropAction
+
     this.context.draggable.onBeginAction(this.props.event, 'resize', 'RIGHT')
+
+    if ((nativeEvent === 'touchend' && !interacting) || touchEndThenMouseDown) {
+      this.context.draggable.onEnd(null)
+    }
   }
   handleStartDragging = e => {
-    if (e.button === 0) {
-      this.context.draggable.onBeginAction(this.props.event, 'move')
+    const lastNativeEvent = this.context.draggable.dragAndDropAction.nativeEvent
+    const nativeEvent = e.nativeEvent.type
+    const touchEndThenMouseDown =
+      lastNativeEvent === 'touchend' && nativeEvent === 'mousedown'
+    const { interacting } = this.context.draggable.dragAndDropAction
+
+    this.context.draggable.onBeginAction(
+      this.props.event,
+      'move',
+      null,
+      nativeEvent
+    )
+
+    if ((nativeEvent === 'touchend' && !interacting) || touchEndThenMouseDown) {
+      this.context.draggable.onEnd(null)
     }
   }
 
@@ -134,6 +191,7 @@ class EventWrapper extends React.Component {
       const newProps = {
         onMouseDown: this.handleStartDragging,
         onTouchStart: this.handleStartDragging,
+        onTouchEnd: this.handleStartDragging,
         // replace original event child with anchor-embellished child
 
         children: (

--- a/src/addons/dragAndDrop/EventWrapper.js
+++ b/src/addons/dragAndDrop/EventWrapper.js
@@ -32,68 +32,28 @@ class EventWrapper extends React.Component {
   handleResizeUp = e => {
     if (e.button !== 0) return
     e.stopPropagation()
-
-    const lastNativeEvent = this.context.draggable.dragAndDropAction.nativeEvent
-    const nativeEvent = e.nativeEvent.type
-    const touchEndThenMouseDown =
-      lastNativeEvent === 'touchend' && nativeEvent === 'mousedown'
-    const { interacting } = this.context.draggable.dragAndDropAction
-
-    this.context.draggable.onBeginAction(this.props.event, 'resize', 'UP')
-
-    if ((nativeEvent === 'touchend' && !interacting) || touchEndThenMouseDown) {
-      this.context.draggable.onEnd(null)
-    }
+    this.handleBeginAction(e, 'resize', 'UP')
   }
   handleResizeDown = e => {
     if (e.button !== 0) return
     e.stopPropagation()
-
-    const lastNativeEvent = this.context.draggable.dragAndDropAction.nativeEvent
-    const nativeEvent = e.nativeEvent.type
-    const touchEndThenMouseDown =
-      lastNativeEvent === 'touchend' && nativeEvent === 'mousedown'
-    const { interacting } = this.context.draggable.dragAndDropAction
-
-    this.context.draggable.onBeginAction(this.props.event, 'resize', 'DOWN')
-
-    if ((nativeEvent === 'touchend' && !interacting) || touchEndThenMouseDown) {
-      this.context.draggable.onEnd(null)
-    }
+    this.handleBeginAction(e, 'resize', 'DOWN')
   }
   handleResizeLeft = e => {
     if (e.button !== 0) return
     e.stopPropagation()
-
-    const lastNativeEvent = this.context.draggable.dragAndDropAction.nativeEvent
-    const nativeEvent = e.nativeEvent.type
-    const touchEndThenMouseDown =
-      lastNativeEvent === 'touchend' && nativeEvent === 'mousedown'
-    const { interacting } = this.context.draggable.dragAndDropAction
-
-    this.context.draggable.onBeginAction(this.props.event, 'resize', 'LEFT')
-
-    if ((nativeEvent === 'touchend' && !interacting) || touchEndThenMouseDown) {
-      this.context.draggable.onEnd(null)
-    }
+    this.handleBeginAction(e, 'resize', 'LEFT')
   }
   handleResizeRight = e => {
     if (e.button !== 0) return
     e.stopPropagation()
-
-    const lastNativeEvent = this.context.draggable.dragAndDropAction.nativeEvent
-    const nativeEvent = e.nativeEvent.type
-    const touchEndThenMouseDown =
-      lastNativeEvent === 'touchend' && nativeEvent === 'mousedown'
-    const { interacting } = this.context.draggable.dragAndDropAction
-
-    this.context.draggable.onBeginAction(this.props.event, 'resize', 'RIGHT')
-
-    if ((nativeEvent === 'touchend' && !interacting) || touchEndThenMouseDown) {
-      this.context.draggable.onEnd(null)
-    }
+    this.handleBeginAction(e, 'resize', 'RIGHT')
   }
   handleStartDragging = e => {
+    this.handleBeginAction(e, 'move')
+  }
+
+  handleBeginAction = (e, action, direction) => {
     const lastNativeEvent = this.context.draggable.dragAndDropAction.nativeEvent
     const nativeEvent = e.nativeEvent.type
     const touchEndThenMouseDown =
@@ -102,8 +62,8 @@ class EventWrapper extends React.Component {
 
     this.context.draggable.onBeginAction(
       this.props.event,
-      'move',
-      null,
+      action,
+      direction,
       nativeEvent
     )
 

--- a/src/addons/dragAndDrop/withDragAndDrop.js
+++ b/src/addons/dragAndDrop/withDragAndDrop.js
@@ -113,8 +113,8 @@ export default function withDragAndDrop(Calendar) {
       }
     }
 
-    handleBeginAction = (event, action, direction) => {
-      this.setState({ event, action, direction })
+    handleBeginAction = (event, action, direction, nativeEvent) => {
+      this.setState({ event, action, direction, nativeEvent })
     }
 
     handleInteractionStart = () => {


### PR DESCRIPTION
I found a couple of bugs with the drag and drop addon with touch devices. You can see them using the iPhone X on Google Chrome Device Toolbar and with Safari on the iPhone (I haven't checked anything else).

These include:
- when you start dragging an event on the week and day view, the event jams (stops moving) and then allows you to drag it after you release then re-press the event (this doesn't happen on the month view)
- if you select an event (without dragging), then try drag to create a new event, the event that you previously selected disappears on week/day view and jumps to the newly selected location on month view

These changes have fixed the issue and I haven't found any other issues.

Thanks!