### PR TITLE
Fix reference to draggable/resizable Accessor

### DIFF
--- a/src/addons/dragAndDrop/EventWrapper.js
+++ b/src/addons/dragAndDrop/EventWrapper.js
@@ -77,7 +77,8 @@ class EventWrapper extends React.Component {
         className: cn(children.props.className, 'rbc-addons-dnd-drag-preview'),
       })
 
-    const { draggableAccessor, resizableAccessor, draggable } = this.context
+    const { draggable } = this.context
+    const { draggableAccessor, resizableAccessor } = draggable
 
     const isDraggable = draggableAccessor
       ? !!get(event, draggableAccessor)


### PR DESCRIPTION
## Summary

The reference to the draggableAccessor/resizableAccessor was incorrect. This PR fixes that.

## Issue

#1068 