### PR TITLE
Fix dragging is disabled if resizing is not allowed

### DIFF
--- a/src/addons/dragAndDrop/EventWrapper.js
+++ b/src/addons/dragAndDrop/EventWrapper.js
@@ -89,9 +89,6 @@ class EventWrapper extends React.Component {
       return children
     }
 
-    let StartAnchor = null
-    let EndAnchor = null
-
     /*
  * The resizability of events depends on whether they are
  * allDay events and how they are displayed.
@@ -115,15 +112,7 @@ class EventWrapper extends React.Component {
       ? !!get(event, resizableAccessor)
       : true
 
-    if (isResizable) {
-      if (type === 'date') {
-        StartAnchor = !continuesPrior && this.renderAnchor('Left')
-        EndAnchor = !continuesAfter && this.renderAnchor('Right')
-      } else {
-        StartAnchor = !continuesPrior && this.renderAnchor('Up')
-        EndAnchor = !continuesAfter && this.renderAnchor('Down')
-      }
-
+    if (isResizable || isDraggable) {
       /*
   * props.children is the singular <Event> component.
   * BigCalendar positions the Event abolutely and we
@@ -135,15 +124,28 @@ class EventWrapper extends React.Component {
       const newProps = {
         onMouseDown: this.handleStartDragging,
         onTouchStart: this.handleStartDragging,
-        // replace original event child with anchor-embellished child
+      }
 
-        children: (
+      if (isResizable) {
+        // replace original event child with anchor-embellished child
+        let StartAnchor = null
+        let EndAnchor = null
+
+        if (type === 'date') {
+          StartAnchor = !continuesPrior && this.renderAnchor('Left')
+          EndAnchor = !continuesAfter && this.renderAnchor('Right')
+        } else {
+          StartAnchor = !continuesPrior && this.renderAnchor('Up')
+          EndAnchor = !continuesAfter && this.renderAnchor('Down')
+        }
+
+        newProps.children = (
           <div className="rbc-addons-dnd-resizable">
             {StartAnchor}
             {children.props.children}
             {EndAnchor}
           </div>
-        ),
+        )
       }
 
       if (


### PR DESCRIPTION
### Summary
Drag and Drop was disabled if resizing is not allowed. This PR should take into account both isDraggable and isResizable when evaluating.

### Issue
#1072