### PR TITLE
Pass resourceId to slotPropGetter

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -481,7 +481,7 @@ class Calendar extends React.Component {
      * position may break the calendar in unexpected ways.
      *
      * ```js
-     * (date: Date) => { className?: string, style?: Object }
+     * (date: Date, resourceId: (number|string)) => { className?: string, style?: Object }
      * ```
      */
     slotPropGetter: PropTypes.func,

--- a/src/TimeSlotGroup.js
+++ b/src/TimeSlotGroup.js
@@ -25,7 +25,7 @@ export default class TimeSlotGroup extends Component {
     return (
       <div className="rbc-timeslot-group">
         {group.map((value, idx) => {
-          const slotProps = getters ? getters.slotProp(value) : {}
+          const slotProps = getters ? getters.slotProp(value, resource) : {}
           return (
             <Wrapper key={idx} value={value} resource={resource}>
               <div


### PR DESCRIPTION
This tiny change enables users of this library to add custom slot classes depending on the slot resource & time.

I think that this is the most flexible solution for visually supporting things like business hours, breaks, times designated to specific types of events and so on. 