### PR TITLE
Fix: do not handle move event after terminating

### DIFF
--- a/src/Selection.js
+++ b/src/Selection.js
@@ -317,6 +317,10 @@ class Selection {
   }
 
   _handleMoveEvent(e) {
+    if (this._initialEventData === null) {
+      return;
+    }
+
     let { x, y } = this._initialEventData
     const { pageX, pageY } = getEventCoordinates(e)
     let w = Math.abs(x - pageX)


### PR DESCRIPTION
Hello!

We were seeing an issue on IE11 while using the drag 'n drop functionality.
Every time I was done selecting some events / slots IE10 crashed on me.

I couldn't investigate much further, but it seems that `_handleMoveEvent` was called after `_handleTerminatingEvent`. This means that while trying to destructure `x` and `y` from this line `let { x, y } = this._initialEventData` that `this._initialEventData` was already set to `null`.

This is currently not a clean solution, but it works for our needs so far.
I am not 100% sure what the root cause is (why `_handleMoveEvent` is called again after terminating).