### PR TITLE
Filter and range should include current day in agenda

### DIFF
--- a/src/Agenda.js
+++ b/src/Agenda.js
@@ -221,7 +221,7 @@ Agenda.navigate = (date, action, { length = Agenda.defaultProps.length }) => {
 }
 
 Agenda.title = (start, { length = Agenda.defaultProps.length, localizer }) => {
-  let end = dates.add(start, length, 'day')
+  let end = dates.add(start, length - 1, 'day')
   return localizer.format({ start, end }, 'agendaHeaderFormat')
 }
 

--- a/src/Agenda.js
+++ b/src/Agenda.js
@@ -38,11 +38,13 @@ class Agenda extends React.Component {
   render() {
     let { length, date, events, accessors, localizer } = this.props
     let { messages } = localizer
-    let end = dates.add(date, length, 'day')
+    let end = dates.add(date, length - 1, 'day')
 
     let range = dates.range(date, end, 'day')
 
-    events = events.filter(event => inRange(event, date, end, accessors))
+    events = events.filter(e =>
+      inRange(e, dates.startOf(date, 'day'), dates.endOf(end, 'day'), accessors)
+    )
 
     events.sort((a, b) => +accessors.start(a) - +accessors.start(b))
 

--- a/src/Agenda.js
+++ b/src/Agenda.js
@@ -38,13 +38,13 @@ class Agenda extends React.Component {
   render() {
     let { length, date, events, accessors, localizer } = this.props
     let { messages } = localizer
+
     let end = dates.add(date, length - 1, 'day')
-
     let range = dates.range(date, end, 'day')
+    let startOfDay = dates.startOf(date, 'day')
+    let endOfDay = dates.endOf(end, 'day')
 
-    events = events.filter(e =>
-      inRange(e, dates.startOf(date, 'day'), dates.endOf(end, 'day'), accessors)
-    )
+    events = events.filter(e => inRange(e, startOfDay, endOfDay, accessors))
 
     events.sort((a, b) => +accessors.start(a) - +accessors.start(b))
 


### PR DESCRIPTION
#850 didn't completely fixed the problem since events are being filtered in the render method and passed to renderDay. The agenda was also including the same day in two different ranges when you navigated forward or back because it was including start and end in the range (it was actually showing lenght + 1 days).