### PR TITLE
Add option to overwrite default TimeGridHeader component

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -636,6 +636,7 @@ class Calendar extends React.Component {
      *   eventContainerWrapper: MyEventContainerWrapper,
      *   dayWrapper: MyDayWrapper,
      *   dateCellWrapper: MyDateCellWrapper,
+     *   timeGridHeader: MyTimeGridHeader,
      *   timeSlotWrapper: MyTimeSlotWrapper,
      *   timeGutterHeader: MyTimeGutterWrapper,
      *   toolbar: MyToolbar,
@@ -667,6 +668,7 @@ class Calendar extends React.Component {
       eventContainerWrapper: elementType,
       dayWrapper: elementType,
       dateCellWrapper: elementType,
+      timeGridHeader: elementType,
       timeSlotWrapper: elementType,
       timeGutterHeader: elementType,
 

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -10,7 +10,7 @@ import DayColumn from './DayColumn'
 import TimeGutter from './TimeGutter'
 
 import getWidth from 'dom-helpers/query/width'
-import TimeGridHeader from './TimeGridHeader'
+import DefaultTimeGridHeader from './TimeGridHeader'
 import { notify } from './utils/helpers'
 import { inRange, sortEvents } from './utils/eventLevels'
 import Resources from './utils/Resources'
@@ -203,6 +203,8 @@ export default class TimeGrid extends Component {
 
     let allDayEvents = [],
       rangeEvents = []
+
+    let TimeGridHeader = components.timeGridHeader || DefaultTimeGridHeader
 
     events.forEach(event => {
       if (inRange(event, start, end, accessors)) {


### PR DESCRIPTION
I would like to overwrite the TimeGridHeader component. Reason is to allow it to be sticky using something like react-sticky.

Eg:

```
import React from 'react';
import TimeGridHeader from 'react-big-calendar/lib/TimeGridHeader';
import { Sticky } from 'react-sticky';

export default function StickyTimeGridHeader(props) {
    return (
        <Sticky topOffset={105}>
            <TimeGridHeader {...props} />
        </Sticky>
    );
}
```