### PR TITLE
fix: short-circuit handleInteractionEnd when no action is in progress

### DIFF
--- a/src/addons/dragAndDrop/withDragAndDrop.js
+++ b/src/addons/dragAndDrop/withDragAndDrop.js
@@ -124,6 +124,8 @@ export default function withDragAndDrop(Calendar) {
     handleInteractionEnd = interactionInfo => {
       const { action, event } = this.state
 
+      if (!action) return
+
       this.setState({
         action: null,
         event: null,


### PR DESCRIPTION
There are many onMouseUp listeners (expecially in week view) , all calling this function, causing many `setState` calls. In particular, those calls do happen when you click an event to select it, severely delaying the feedback from the click.

I assumed if `state.action` is null, then the setState call is redundant, not sure if anything relies on this handler always causing a render or not. I tested for my use case and it works well. Reacting to a simple `onClick` on an event is now ~10x faster.