### PR TITLE
improve date manipulation performance

### DIFF
--- a/src/Agenda.js
+++ b/src/Agenda.js
@@ -42,7 +42,9 @@ class Agenda extends React.Component {
 
     let range = dates.range(date, end, 'day')
 
-    events = events.filter(event => inRange(event, date, end, accessors))
+    const dayAfter = dates.dayAfter(end)
+
+    events = events.filter(event => inRange(event, date, dayAfter, accessors))
 
     events.sort((a, b) => +accessors.start(a) - +accessors.start(b))
 
@@ -87,9 +89,10 @@ class Agenda extends React.Component {
       components: { event: Event, date: AgendaDate },
     } = this.props
 
-    events = events.filter(e =>
-      inRange(e, dates.startOf(day, 'day'), dates.endOf(day, 'day'), accessors)
-    )
+    const startOfDay = dates.startOf(day, 'day')
+    const endOfDay = dates.endOf(day, 'day')
+
+    events = events.filter(e => inRange(e, startOfDay, endOfDay, accessors))
 
     return events.map((event, idx) => {
       let title = accessors.title(event)

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -507,6 +507,15 @@ class Calendar extends React.Component {
     showMultiDayTimes: PropTypes.bool,
 
     /**
+     * When enabled, events where both start and end don't have a time (eg: 00:00:00)
+     * are considered all-day events even if the allDay accessor returns false.
+     *
+     * **Note: Disabling this can lead to significant performance improvements when dealing
+     * with many events
+     */
+    autoDetectAllDayEvents: PropTypes.bool,
+
+    /**
      * Constrains the minimum _time_ of the Day and Week views.
      */
     min: PropTypes.instanceOf(Date),
@@ -736,6 +745,8 @@ class Calendar extends React.Component {
 
     longPressThreshold: 250,
     getNow: () => new Date(),
+
+    autoDetectAllDayEvents: true,
   }
 
   constructor(...args) {
@@ -847,6 +858,7 @@ class Calendar extends React.Component {
       getNow,
       length,
       showMultiDayTimes,
+      autoDetectAllDayEvents,
       components: _0,
       formats: _1,
       messages: _2,
@@ -897,6 +909,7 @@ class Calendar extends React.Component {
           components={components}
           accessors={accessors}
           showMultiDayTimes={showMultiDayTimes}
+          autoDetectAllDayEvents={autoDetectAllDayEvents}
           getDrilldownView={this.getDrilldownView}
           onNavigate={this.handleNavigate}
           onDrillDown={this.handleDrillDown}

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -31,6 +31,7 @@ class DayColumn extends React.Component {
     localizer: PropTypes.object.isRequired,
 
     showMultiDayTimes: PropTypes.bool,
+    autoDetectAllDayEvents: PropTypes.bool,
     culture: PropTypes.string,
     timeslots: PropTypes.number,
 

--- a/src/Month.js
+++ b/src/Month.js
@@ -19,8 +19,10 @@ import DateHeader from './DateHeader'
 
 import { inRange, sortEvents } from './utils/eventLevels'
 
-let eventsForWeek = (evts, start, end, accessors) =>
-  evts.filter(e => inRange(e, start, end, accessors))
+let eventsForWeek = (evts, start, end, accessors) => {
+  const dayAfterEnd = dates.dayAfter(end)
+  return evts.filter(e => inRange(e, start, dayAfterEnd, accessors))
+}
 
 let propTypes = {
   events: PropTypes.array.isRequired,

--- a/src/utils/TimeSlots.js
+++ b/src/utils/TimeSlots.js
@@ -13,11 +13,7 @@ export function getSlotMetrics({ min: start, max: end, step, timeslots }) {
 
   const totalMin =
     1 + dates.diff(start, end, 'minutes') + getDstOffset(start, end)
-  const minutesFromMidnight = dates.diff(
-    dates.startOf(start, 'day'),
-    start,
-    'minutes'
-  )
+  const minutesFromMidnight = start.getMinutes() + start.getHours() * 60
 
   const numGroups = Math.ceil(totalMin / (step * timeslots))
   const numSlots = numGroups * timeslots

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -83,6 +83,14 @@ let dates = {
     )
   },
 
+  eqDate(date, otherDate) {
+    return (
+      date.getDate() === otherDate.getDate() &&
+      date.getMonth() === otherDate.getMonth() &&
+      date.getFullYear() === otherDate.getFullYear()
+    )
+  },
+
   isJustDate(date) {
     return (
       dates.hours(date) === 0 &&
@@ -145,12 +153,18 @@ let dates = {
     return dates.startOf(new Date(), 'day')
   },
 
-  yesterday() {
-    return dates.add(dates.startOf(new Date(), 'day'), -1, 'day')
+  dayAfter(date) {
+    const dayAfter = new Date(date.getTime())
+    dayAfter.setDate(dayAfter.getDate() + 1)
+
+    return dayAfter
   },
 
-  tomorrow() {
-    return dates.add(dates.startOf(new Date(), 'day'), 1, 'day')
+  dayBefore(date) {
+    const dayBefore = new Date(date.getTime())
+    dayBefore.setDate(dayBefore.getDate() - 1)
+
+    return dayBefore
   },
 }
 

--- a/test/utils/eventLevels.test.js
+++ b/test/utils/eventLevels.test.js
@@ -261,107 +261,71 @@ describe('inRange', () => {
         expect(inRange(event, rangeStart, rangeEnd, accessors)).toBe(result)
       })
     }
-    const weekOfThe5th = [d(5), d(11)]
-    const weekOfThe12th = [d(12), d(18)]
-    ;[
-      [
-        'single day with time, 1 day range',
-        { start: d(11, 5), end: d(11, 6) },
-        [d(11), d(11)],
-        true,
-      ],
-      [
-        'multiday w/ time, 1 day range',
-        { start: d(10, 5), end: d(11, 6) },
-        [d(11), d(11)],
-        true,
-      ],
-      [
-        'single day event, end of the week',
-        { start: d(11), end: d(12) },
-        weekOfThe5th,
-        true,
-      ],
-      [
-        'single day event, middle of the week',
-        { start: d(10), end: d(11) },
-        weekOfThe5th,
-        true,
-      ],
-      [
-        'single day event, end of the week',
-        { start: d(11), end: d(12) },
-        weekOfThe12th,
-        false,
-      ],
 
+    const sample = [
       [
-        'no duration, first of the week',
-        { start: d(12), end: d(12) },
-        weekOfThe12th,
+        'whole day, event contained',
+        { start: d(11, 5), end: d(11, 6) },
+        [d(11), d(12)],
         true,
       ],
       [
-        'no duration, end of the week',
+        'whole day, event crosses start',
+        { start: d(10, 5), end: d(11, 5) },
+        [d(11), d(12)],
+        true,
+      ],
+      [
+        'whole day, event crosses end',
+        { start: d(11, 5), end: d(12, 5) },
+        [d(11), d(12)],
+        true,
+      ],
+      [
+        'whole day, event overlaps start',
+        { start: d(10), end: d(11) },
+        [d(11), d(12)],
+        true,
+      ],
+      [
+        'whole day, event overlaps end',
+        { start: d(12), end: d(12, 5) },
+        [d(11), d(12)],
+        false,
+      ],
+      [
+        'whole day, event with zero duration overlaps start',
         { start: d(11), end: d(11) },
-        weekOfThe5th,
+        [d(11), d(12)],
         true,
       ],
       [
-        'no duration, first of the next week',
+        'whole day, event with zero duration overlaps end',
         { start: d(12), end: d(12) },
-        weekOfThe5th,
-        false,
-      ],
-      [
-        'no duration, middle of the week',
-        { start: d(14), end: d(14) },
-        weekOfThe12th,
+        [d(11), d(12)],
         true,
       ],
       [
-        'single day w/ time event, end of the week',
-        { start: d(11, 10), end: d(11, 12) },
-        weekOfThe5th,
+        'whole day, event with same duration',
+        { start: d(11), end: d(12) },
+        [d(11), d(12)],
         true,
       ],
       [
-        'single day w/ time event, end of the week',
-        { start: d(11, 10), end: d(11, 12) },
-        weekOfThe12th,
-        false,
-      ],
-      [
-        'multi day w/ time event, end of the week',
-        { start: d(11, 10), end: d(13, 12) },
-        weekOfThe12th,
+        'whole day, event longer than range',
+        { start: d(10), end: d(13) },
+        [d(11), d(12)],
         true,
       ],
       [
-        'single day w/ time event, middle of the week',
-        { start: d(10, 10), end: d(10, 12) },
-        weekOfThe5th,
+        'whole day, event longer than range',
+        { start: d(10), end: d(13) },
+        [d(11), d(12)],
         true,
       ],
-      [
-        'multi day event, first of the week',
-        { start: d(11), end: d(13) },
-        weekOfThe5th,
-        true,
-      ],
-      [
-        'multi day event, midnight of next the week',
-        { start: d(11), end: d(13) },
-        weekOfThe12th,
-        true,
-      ],
-      [
-        'multi day event w/ time, first of next the week',
-        { start: d(11, 5), end: d(13, 5) },
-        weekOfThe12th,
-        true,
-      ],
-    ].forEach(g => compare(...g))
+    ]
+
+    sample.forEach(g => compare(...g))
   })
 
   test('it returns true when event starts before the range end and ends after the range start', () => {
@@ -390,17 +354,6 @@ describe('inRange', () => {
 
   test('it returns true when event spans the whole range', () => {
     const event = { start: new Date(2017, 4, 1), end: new Date(2017, 5, 1) }
-
-    const result = inRange(event, rangeStart, rangeEnd, accessors)
-
-    expect(result).toBeTruthy()
-  })
-
-  test('it uses the start of the day for the event start date', () => {
-    const event = {
-      start: new Date(2017, 4, 1, 12),
-      end: new Date(2017, 5, 1),
-    }
 
     const result = inRange(event, rangeStart, rangeEnd, accessors)
 


### PR DESCRIPTION
After debugging performance issues with a very heavily loaded calendar (~300 events per day across ~15 resources, 3 months of events passed in the `events` variable), I realized a couple functions were responsible for over 90% of the processing time.

This version is an order of magnitude faster for my use-case, going from ~900ms to < 70ms to render a heavily loaded week-view.

The main culprit I found was `date-arithmetic`, especially the `startOf` function, that while written very elegantly has absolutely horrible performance as it mutates the date many times.

While debugging it, I also realized `eventLevels.inRange` implementation was very costly, and could be sped up 10-20x by changing the input params a bit (passing the real range we want to filter and just using `<` and `>`).

I also added a autoDetectAllDayEvents prop to the calendar, that is true by default. Changing it to false will stop analysing every event time to see if both start and end are 00:00:00.

This works theoretically and I've tested it with my dataset, but there might be corner cases I'm not thinking of (zero time events combined with something else, daylight savivng, etc?).

Thanks in advance for having an in-depth look!