### PR TITLE
changes to allow calendar to work with React 15.6.2

### DIFF
--- a/src/Agenda.js
+++ b/src/Agenda.js
@@ -49,7 +49,7 @@ class Agenda extends React.Component {
     return (
       <div className="rbc-agenda-view">
         {events.length !== 0 ? (
-          <React.Fragment>
+          <div>
             <table ref="header" className="rbc-agenda-table">
               <thead>
                 <tr>
@@ -70,7 +70,7 @@ class Agenda extends React.Component {
                 </tbody>
               </table>
             </div>
-          </React.Fragment>
+          </div>
         ) : (
           <span className="rbc-agenda-empty">{messages.noEventsInRange}</span>
         )}

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -64,7 +64,7 @@ export default class TimeGrid extends Component {
 
     this.state = { gutterWidth: undefined, isOverflowing: null }
 
-    this.scrollRef = React.createRef()
+    this.scrollRef = null;
 
     this.resources = Resources(props.resources, props.accessors)
   }
@@ -175,6 +175,10 @@ export default class TimeGrid extends Component {
     )
   }
 
+  setScrollRef = (el) => {
+    this.scrollRef = el;
+  }
+
   render() {
     let {
       events,
@@ -238,7 +242,7 @@ export default class TimeGrid extends Component {
           accessors={accessors}
           getters={getters}
           components={components}
-          scrollRef={this.scrollRef}
+          scrollRef={this.setScrollRef}
           isOverflowing={this.state.isOverflowing}
           longPressThreshold={longPressThreshold}
           onSelectSlot={this.handleSelectAllDaySlot}

--- a/src/addons/dragAndDrop/EventContainerWrapper.js
+++ b/src/addons/dragAndDrop/EventContainerWrapper.js
@@ -208,7 +208,7 @@ class EventContainerWrapper extends React.Component {
 
     return React.cloneElement(children, {
       children: (
-        <React.Fragment>
+        <div>
           {events}
 
           {event && (
@@ -224,7 +224,7 @@ class EventContainerWrapper extends React.Component {
               continuesLater={startsAfterDay}
             />
           )}
-        </React.Fragment>
+        </div>
       ),
     })
   }


### PR DESCRIPTION
Hey all, came across an issue when upgrading to the latest calendar (v0.20.1). It's using `React.createRef()`, but my app is currently on React 15.6.2 which does not have the API. The latest calendar had features which I really wanted, but I currently do not have the time to upgrade the app, and so I went through and just made some small changes so that it is no longer using the createRef.