### PR TITLE
Added fallback to getNow in `handleViewChange`

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -952,7 +952,7 @@ class Calendar extends React.Component {
     }
 
     let views = this.getViews()
-    this.handleRangeChange(this.props.date, views[view], view)
+    this.handleRangeChange(this.props.date || this.props.getNow(), views[view], view)
   }
 
   handleSelectEvent = (...args) => {


### PR DESCRIPTION
When view changed and props `date === undefined` we have unexpected behavior for `handleRangeChange` and then for `onRangeChange` methods. It returns sometimes `undefined` and sometimes `Invalid Date`, so I suggest fix for this to provide default date if `date` prop isn't present.

@jquense