### PR TITLE
feat: add an alternate layout algorithm, allow using a custom one

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -17,6 +17,7 @@ import { mergeWithDefaults } from './localizer'
 import message from './utils/messages'
 import moveDate from './utils/move'
 import VIEWS from './Views'
+import LAYOUTS from './Layouts'
 import Toolbar from './Toolbar'
 import NoopWrapper from './NoopWrapper'
 
@@ -498,6 +499,33 @@ class Calendar extends React.Component {
     dayPropGetter: PropTypes.func,
 
     /**
+     * Optionally provide a function that returns an array of events along with their position
+     * on the grid. `top`, `height`, `width` and `xOffset` are interpreted as a percentage of
+     * the total height and width of the DayColumn parent, e.g. 50 = half
+     *
+     * ```js
+     * ({
+     *   events: Events[]
+     *   slotMetrics: SlotMetrics
+     *   accessors: {
+     *       start: (Event) => Date
+     *       end: (Event) => Date
+     *   }
+     *   minimumStartDifference: number
+     * }) => {
+     *   event: Event
+     *   style: {
+     *     top: number
+     *     height: number,
+     *     width: number,
+     *     xOffset: number,
+     *   }
+     * }[]
+     * ```
+     */
+    positionedEventsGetter: PropTypes.func,
+
+    /**
      * Support to show multi-day events with specific start and end times in the
      * main time grid (rather than in the all day header).
      *
@@ -736,6 +764,8 @@ class Calendar extends React.Component {
 
     longPressThreshold: 250,
     getNow: () => new Date(),
+
+    positionedEventsGetter: LAYOUTS.DEFAULT,
   }
 
   constructor(...args) {
@@ -952,7 +982,11 @@ class Calendar extends React.Component {
     }
 
     let views = this.getViews()
-    this.handleRangeChange(this.props.date || this.props.getNow(), views[view], view)
+    this.handleRangeChange(
+      this.props.date || this.props.getNow(),
+      views[view],
+      view
+    )
   }
 
   handleSelectEvent = (...args) => {

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -9,7 +9,6 @@ import * as TimeSlotUtils from './utils/TimeSlots'
 import { isSelected } from './utils/selection'
 
 import { notify } from './utils/helpers'
-import * as DayEventLayout from './utils/DayEventLayout'
 import TimeSlotGroup from './TimeSlotGroup'
 import TimeGridEvent from './TimeGridEvent'
 
@@ -47,6 +46,8 @@ class DayColumn extends React.Component {
     className: PropTypes.string,
     dragThroughEvents: PropTypes.bool,
     resource: PropTypes.any,
+
+    positionedEventsGetter: PropTypes.func.isRequired,
   }
 
   static defaultProps = {
@@ -208,12 +209,13 @@ class DayColumn extends React.Component {
       components,
       step,
       timeslots,
+      positionedEventsGetter,
     } = this.props
 
     const { slotMetrics } = this
     const { messages } = localizer
 
-    let styledEvents = DayEventLayout.getStyledEvents({
+    let styledEvents = positionedEventsGetter({
       events,
       accessors,
       slotMetrics,

--- a/src/Layouts.js
+++ b/src/Layouts.js
@@ -1,0 +1,10 @@
+import { layouts } from './utils/constants'
+import defaultLayout from './layouts/default'
+import packedLayout from './layouts/packed'
+
+const LAYOUTS = {
+  [layouts.DEFAULT]: defaultLayout,
+  [layouts.PACKED]: packedLayout,
+}
+
+export default LAYOUTS

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -50,6 +50,8 @@ export default class TimeGrid extends Component {
     onDoubleClickEvent: PropTypes.func,
     onDrillDown: PropTypes.func,
     getDrilldownView: PropTypes.func.isRequired,
+
+    positionedEventsGetter: PropTypes.func.isRequired,
   }
 
   static defaultProps = {
@@ -94,7 +96,7 @@ export default class TimeGrid extends Component {
     raf.cancel(this.rafHandle)
     this.rafHandle = raf(this.checkOverflow)
   }
-  
+
   componentWillUnmount() {
     window.removeEventListener('resize', this.handleResize)
 
@@ -145,7 +147,7 @@ export default class TimeGrid extends Component {
     let { min, max, components, accessors, localizer } = this.props
 
     const resources = this.memoizedResources(this.props.resources, accessors)
-    const groupedEvents = resources.groupEvents(events) 
+    const groupedEvents = resources.groupEvents(events)
 
     return resources.map(([id, resource], i) =>
       range.map((date, jj) => {
@@ -316,5 +318,7 @@ export default class TimeGrid extends Component {
     }
   }
 
-  memoizedResources = memoize((resources, accessors) => Resources(resources, accessors))
+  memoizedResources = memoize((resources, accessors) =>
+    Resources(resources, accessors)
+  )
 }

--- a/src/index.js
+++ b/src/index.js
@@ -5,11 +5,13 @@ import momentLocalizer from './localizers/moment'
 import globalizeLocalizer from './localizers/globalize'
 import move from './utils/move'
 import { views, navigate } from './utils/constants'
+import Layouts from './Layouts'
 
 Object.assign(Calendar, {
   globalizeLocalizer,
   momentLocalizer,
   Views: views,
+  Layouts,
   Navigate: navigate,
   move,
   components: {

--- a/src/layouts/default.js
+++ b/src/layouts/default.js
@@ -128,7 +128,7 @@ function sortByRender(events) {
   return sorted
 }
 
-function getStyledEvents({
+export default function getPositionedEvents({
   events,
   minimumStartDifference,
   slotMetrics,
@@ -196,5 +196,3 @@ function getStyledEvents({
     },
   }))
 }
-
-export { getStyledEvents }

--- a/src/layouts/packed.js
+++ b/src/layouts/packed.js
@@ -1,0 +1,86 @@
+class Event {
+  constructor(data, { accessors, slotMetrics }) {
+    const {
+      start,
+      startDate,
+      end,
+      endDate,
+      top,
+      height,
+    } = slotMetrics.getRange(accessors.start(data), accessors.end(data))
+
+    this.start = start
+    this.end = end
+    this.startMs = startDate.getTime()
+    this.endMs = endDate.getTime()
+    this.top = top
+    this.height = height
+    this.data = data
+  }
+}
+
+export default function getPositionedEvents({
+  events: rawEvents,
+  slotMetrics,
+  accessors,
+}) {
+  const events = rawEvents
+    .map(event => new Event(event, { accessors, slotMetrics }))
+    .sort((a, b) => {
+      if (a.height === b.height) {
+        return a.startMs - b.startMs
+      }
+
+      return b.height - a.height
+    })
+
+  const columns = []
+
+  return events
+    .map(event => {
+      let currentColumnIndex = 0
+      let availableColumnIndex = null
+      while (availableColumnIndex === null) {
+        if (!columns[currentColumnIndex]) {
+          columns.push([])
+        }
+
+        const currentColumn = columns[currentColumnIndex]
+
+        let overlap = false
+        for (
+          let eventIndex = 0;
+          eventIndex < currentColumn.length;
+          eventIndex++
+        ) {
+          const existingEvent = currentColumn[eventIndex]
+          if (event.start >= existingEvent.end) continue
+          if (event.end <= existingEvent.start) continue
+
+          // overlap with existing event
+          overlap = true
+        }
+
+        if (overlap) {
+          currentColumnIndex++
+        } else {
+          columns[currentColumnIndex].push(event)
+          availableColumnIndex = currentColumnIndex
+        }
+      }
+
+      return [event, availableColumnIndex]
+    })
+    .map(([event, availableColumnIndex]) => ({
+      event: event.data,
+      style: {
+        top: event.top,
+        height: event.height,
+        width: 100 / columns.length,
+        xOffset:
+          availableColumnIndex === 0
+            ? 0
+            : (availableColumnIndex / columns.length) * 100,
+      },
+    }))
+}

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -12,3 +12,8 @@ export let views = {
   DAY: 'day',
   AGENDA: 'agenda',
 }
+
+export const layouts = {
+  DEFAULT: 'DEFAULT',
+  PACKED: 'PACKED',
+}

--- a/test/layouts/default.js
+++ b/test/layouts/default.js
@@ -1,8 +1,8 @@
-import { getStyledEvents } from '../../src/utils/DayEventLayout'
+import getPositionedEvents from '../../src/layouts/default'
 import { getSlotMetrics } from '../../src/utils/TimeSlots'
 import dates from '../../src/utils/dates'
 
-describe('getStyledEvents', () => {
+describe('getPositionedEvents', () => {
   const d = (...args) => new Date(2015, 3, 1, ...args)
   const min = dates.startOf(d(), 'day')
   const max = dates.endOf(d(), 'day')
@@ -12,7 +12,7 @@ describe('getStyledEvents', () => {
   describe('matrix', () => {
     function compare(title, events, expectedResults) {
       it(title, () => {
-        const styledEvents = getStyledEvents({
+        const styledEvents = getPositionedEvents({
           events,
           accessors,
           slotMetrics,


### PR DESCRIPTION
Provides a new algorithm that doesn't stack events, instead packing them similarly to fullcalendar, but with constant width.

Also enables passing a custom algorithm through the `positionedEventsGetter` prop.

This is a WiP, I'm opening a pull request so you guys can have a look. There are no tests for the new layout, I'll get to that when I have some time.