### PR TITLE
Bump react peer dependency to 16.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "bracketSpacing": true
   },
   "peerDependencies": {
-    "react": "^15.3.0 || ^16.0.0",
-    "react-dom": "^15.3.0 || ^16.0.0"
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0"
   },
   "devDependencies": {
     "@4c/rollout": "^1.2.0",


### PR DESCRIPTION
[TimeGrid](https://github.com/intljusticemission/react-big-calendar/blob/master/src/TimeGrid.js#L68) relies on `React.createRef`, which was added in React v16.3.