### PR TITLE
Calendar handleNavigate: fixed missed argument for handleRangeChange

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -943,7 +943,7 @@ class Calendar extends React.Component {
     })
 
     onNavigate(date, view, action)
-    this.handleRangeChange(date, ViewComponent)
+    this.handleRangeChange(date, ViewComponent, view)
   }
 
   handleViewChange = view => {


### PR DESCRIPTION
Hi, @jquense, this is related with #1100. Past time I didn't cover `handleNavigate` which is also calls `handleRangeChange`