### PR TITLE
Remove global window from code called during server-side rendering

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,8 @@ parser: babel-eslint
 extends:
   - jason/react
   - prettier
-
+env:
+  es6: true
 rules:
   global-require: off
   no-unused-vars: [2, {

--- a/src/utils/Resources.js
+++ b/src/utils/Resources.js
@@ -10,7 +10,7 @@ export default function Resources(resources, accessors) {
     },
 
     groupEvents(events) {
-      const eventsByResource = new window.Map()
+      const eventsByResource = new Map()
 
       if (!resources) {
         // Return all events if resources are not provided


### PR DESCRIPTION
When I render RBC on the server with the `week` view, it produces an error with the following stack trace:

```
ReferenceError: window is not defined
    at Object.groupEvents (/[project path]/node_modules/react-big-calendar/lib/utils/Resources.js:18:30)
    at TimeGrid.renderEvents (/[project path]/node_modules/react-big-calendar/lib/TimeGrid.js:166:35)
    at TimeGrid.render (/[project path]/node_modules/react-big-calendar/lib/TimeGrid.js:263:14)
    at processChild (/[project path]/node_modules/react-dom/cjs/react-dom-server.node.development.js:2863:18)
```
This is due to using `window.Map()` instead of simply `Map()` in `utils/Resources.js`. While all node versions going back to v0.12 support the ES6 `Map`, node has no `window`, hence the break. 

All tests pass with the change, and to satisfy the eslint `global-require` rule I've added the `es6` environment.

Please let me know if you've got any questions/comments/concerns. Thanks for all your hard work on this excellent library.