### PR TITLE
Able to override onShowMore callback

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -324,6 +324,15 @@ class Calendar extends React.Component {
     onSelecting: PropTypes.func,
 
     /**
+     * Callback fired when a +{count} more is clicked
+     *
+     * ```js
+     * (events: Object, date: Date) => any
+     * ```
+     */
+    onShowMore: PropTypes.func,
+
+    /**
      * The selected event, if any.
      */
     selected: PropTypes.object,
@@ -847,6 +856,7 @@ class Calendar extends React.Component {
       getNow,
       length,
       showMultiDayTimes,
+      onShowMore,
       components: _0,
       formats: _1,
       messages: _2,
@@ -903,7 +913,7 @@ class Calendar extends React.Component {
           onSelectEvent={this.handleSelectEvent}
           onDoubleClickEvent={this.handleDoubleClickEvent}
           onSelectSlot={this.handleSelectSlot}
-          onShowMore={this._showMore}
+          onShowMore={onShowMore}
         />
       </div>
     )


### PR DESCRIPTION
I've replaced `this._showMore` by callback from props. Seems it was added by mistake [here](https://github.com/intljusticemission/react-big-calendar/blob/f9a873368a78f5ced81b799c4dffe1095b3ab712/src/Calendar.jsx#L280), `_showMore` is always undefined.

Here it will be execute:
https://github.com/intljusticemission/react-big-calendar/blob/1d62c432eaa183ed6b38f08cfcec5ee7edcbfe41/src/Month.js#L300-L307

Related to #1147 