### PR TITLE
sass version added

### DIFF
--- a/src/sass/_partials/_agenda.scss
+++ b/src/sass/_partials/_agenda.scss
@@ -1,0 +1,71 @@
+.rbc-agenda-view {
+  display: flex;
+  flex-direction: column;
+  flex: 1 0 0;
+  overflow: auto;
+
+  table.rbc-agenda-table {
+    width: 100%;
+    border: 1px solid $cell-border;
+    border-spacing: 0;
+    border-collapse: collapse;
+
+    tbody > tr > td {
+      padding: 5px 10px;
+      vertical-align: top;
+    }
+
+    .rbc-agenda-time-cell {
+      padding-left: 15px;
+      padding-right: 15px;
+      text-transform: lowercase;
+    }
+
+    tbody > tr > td + td {
+      border-left: 1px solid $cell-border;
+    }
+
+    .rbc-rtl & {
+      tbody > tr > td + td {
+        border-left-width: 0;
+        border-right: 1px solid $cell-border;
+      }
+    }
+
+    tbody > tr + tr {
+      border-top: 1px solid $cell-border;
+    }
+
+    thead > tr > th {
+      padding: 3px 5px;
+      text-align: left;
+      border-bottom: 1px solid $cell-border;
+
+      .rbc-rtl & {
+        text-align: right;
+      }
+    }
+  }
+}
+
+.rbc-agenda-time-cell {
+  text-transform: lowercase;
+
+  .rbc-continues-after:after {
+    content: ' »'
+  }
+  .rbc-continues-prior:before {
+    content: '« '
+  }
+}
+
+.rbc-agenda-date-cell,
+.rbc-agenda-time-cell {
+  white-space: nowrap;
+}
+
+
+
+.rbc-agenda-event-cell {
+  width: 100%
+}

--- a/src/sass/_partials/_event.scss
+++ b/src/sass/_partials/_event.scss
@@ -1,0 +1,54 @@
+.rbc-event {
+    border: none;
+    box-shadow: none;
+    margin: 0;
+    padding: $event-padding;
+    background-color: $event-bg;
+    border-radius: $event-border-radius;
+    color: $event-color;
+    cursor: pointer;
+    width: 100%;
+    text-align: left;
+  
+    .rbc-slot-selecting & {
+      cursor: inherit;
+      pointer-events: none;
+    }
+  
+    &.rbc-selected {
+      background-color: darken($event-bg, 10%);
+    }
+  
+    &:focus {
+      outline: 5px auto $event-outline;
+    }
+  }
+  
+  .rbc-event-label {
+    @extend %rbc-ellipsis;
+    font-size: 80%;
+  }
+  
+  .rbc-event-overlaps {
+    box-shadow: -1px 1px 5px 0px rgba(51,51,51,.5);
+  }
+  
+  .rbc-event-continues-prior {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+  .rbc-event-continues-after {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+  
+  
+  .rbc-event-continues-earlier {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
+  .rbc-event-continues-later {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+  

--- a/src/sass/_partials/_month.scss
+++ b/src/sass/_partials/_month.scss
@@ -1,0 +1,121 @@
+
+.rbc-row {
+  display: flex;
+  flex-direction: row;
+}
+
+.rbc-row-segment {
+  padding: 0 1px 1px 1px;
+
+  .rbc-event-content {
+    @extend %rbc-ellipsis;
+  }
+}
+
+.rbc-selected-cell {
+  background-color: $date-selection-bg-color;
+}
+
+
+.rbc-show-more {
+  @extend %rbc-ellipsis;
+  background-color: rgba(255, 255, 255, 0.3);
+  z-index: $event-zindex;
+  font-weight: bold;
+  font-size: 85%;
+  height: auto;
+  line-height: normal;
+  white-space: nowrap;
+}
+
+.rbc-month-view {
+  position: relative;
+  border: 1px solid $calendar-border;
+  display: flex;
+  flex-direction: column;
+  flex: 1 0 0;
+  width: 100%;
+  user-select: none;
+  -webkit-user-select: none;
+
+  height: 100%; // ie-fix
+}
+
+.rbc-month-header {
+  display: flex;
+  flex-direction: row;
+}
+
+.rbc-month-row {
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  flex: 1 0 0; // postcss will remove the 0px here hence the duplication below
+  flex-basis: 0px;
+  overflow: hidden;
+
+  height: 100%; // ie-fix
+
+  & + & {
+    border-top: 1px solid $cell-border;
+  }
+}
+
+.rbc-date-cell {
+  flex: 1 1 0;
+  min-width: 0;
+  padding-right: 5px;
+  text-align: right;
+
+  &.rbc-now {
+    font-weight: bold;
+  }
+
+  > a {
+    &, &:active, &:visited {
+      color: inherit;
+      text-decoration: none;
+    }
+  }
+}
+
+.rbc-row-bg {
+  @extend %rbc-abs-full;
+  display: flex;
+  flex-direction: row;
+  flex: 1 0 0;
+  overflow: hidden;
+}
+
+.rbc-day-bg {
+  flex: 1 0 0%;
+
+  & + & {
+    border-left: 1px solid $cell-border;
+  }
+
+  .rbc-rtl & + & {
+    border-left-width: 0;
+    border-right: 1px solid $cell-border;
+  }
+}
+
+.rbc-overlay {
+  position: absolute;
+  z-index: $event-zindex + 1;
+  border: 1px solid #e5e5e5;
+  background-color: #fff;
+  box-shadow: 0 5px 15px rgba(0,0,0,.25);
+  padding: 10px;
+
+  > * + * {
+    margin-top: 1px;
+  }
+}
+
+.rbc-overlay-header {
+  border-bottom: 1px solid #e5e5e5;
+  margin: -10px -10px 5px -10px ;
+  padding: 2px 10px;
+}
+

--- a/src/sass/_partials/_reset.scss
+++ b/src/sass/_partials/_reset.scss
@@ -1,0 +1,21 @@
+.rbc-btn {
+  color: inherit;
+  font: inherit;
+  margin: 0;
+}
+
+button.rbc-btn {
+  overflow: visible;
+  text-transform: none;
+  -webkit-appearance: button;
+  cursor: pointer;
+}
+
+button[disabled].rbc-btn {
+  cursor: not-allowed;
+}
+
+button.rbc-input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}

--- a/src/sass/_partials/_time-column.scss
+++ b/src/sass/_partials/_time-column.scss
@@ -1,0 +1,126 @@
+.rbc-time-column {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+
+  .rbc-timeslot-group {
+    flex: 1;
+  }
+}
+
+
+.rbc-timeslot-group {
+  border-bottom: 1px solid $cell-border;
+  min-height: 40px;
+  display: flex;
+  flex-flow: column nowrap;
+}
+
+.rbc-time-gutter,
+.rbc-header-gutter {
+  flex: none;
+}
+
+.rbc-label {
+  padding: 0 5px;
+}
+
+.rbc-day-slot {
+  position: relative;
+
+  .rbc-events-container {
+    bottom: 0;
+    left: 0;
+    position: absolute;
+    right: 0;
+    margin-right: 10px;
+    top: 0;
+
+    &.rbc-is-rtl {
+      left: 10px;
+      right: 0;
+    }
+  }
+
+  .rbc-event {
+    border: 1px solid $event-border;
+    display: flex;
+    max-height: 100%;
+    min-height: 20px;
+    flex-flow: column wrap;
+    align-items: flex-start;
+    overflow: hidden;
+    position: absolute;
+  }
+
+  .rbc-event-label {
+    flex: none;
+    padding-right: 5px;
+    width: auto;
+  }
+
+  .rbc-event-content {
+    width: 100%;
+    flex: 1 1 0;
+    word-wrap: break-word;
+    line-height: 1;
+    height: 100%;
+    min-height: 1em;
+  }
+
+  .rbc-time-slot {
+    border-top: 1px solid lighten($cell-border, 10%);
+  }
+}
+
+.rbc-time-view-resources {
+  .rbc-time-gutter,
+  .rbc-time-header-gutter {
+    position: sticky;
+    left: 0;
+    background-color: white;
+    border-right: 1px solid $cell-border;
+    z-index: 10;
+    margin-right: -1px;
+  }
+
+  .rbc-time-header {
+    overflow: hidden;
+  }
+
+  .rbc-time-header-content {
+    min-width: auto;
+    flex: 1 0 0;
+    flex-basis: 0px;
+  }
+
+  .rbc-time-header-cell-single-day {
+    display: none;
+  }
+
+  .rbc-day-slot {
+    min-width: 140px;
+  }
+
+  .rbc-header, .rbc-day-bg {
+    width: 140px;    
+    flex: 1 1 0;
+    flex-basis: 0 px;
+  }
+}
+
+.rbc-time-header-content + .rbc-time-header-content {
+  margin-left: -1px;
+}
+
+.rbc-time-slot {
+  flex: 1 0 0;
+
+  &.rbc-now {
+    font-weight: bold;
+  }
+}
+
+.rbc-day-header {
+  text-align: center;
+}

--- a/src/sass/_partials/_time-grid.scss
+++ b/src/sass/_partials/_time-grid.scss
@@ -1,0 +1,136 @@
+@import './time-column';
+
+.rbc-slot-selection {
+  z-index: 10;
+  position: absolute;
+  background-color: $time-selection-bg-color;
+  color: $time-selection-color;
+  font-size: 75%;
+  width: 100%;
+  padding: 3px;
+}
+
+.rbc-slot-selecting {
+  cursor: move;
+}
+
+.rbc-time-view {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  width: 100%;
+  border: 1px solid $calendar-border;
+  min-height: 0;
+
+  .rbc-time-gutter {
+    white-space: nowrap;
+  }
+
+  .rbc-allday-cell {
+    box-sizing: content-box;
+    width: 100%;
+    height: 100%;
+    position: relative;
+  }
+  .rbc-allday-cell + .rbc-allday-cell {
+    border-left: 1px solid $cell-border;
+  }
+
+  .rbc-allday-events {
+    position: relative;
+    z-index: 4;
+  }
+
+  .rbc-row {
+    box-sizing: border-box;
+    min-height: 20px;
+  }
+}
+
+.rbc-time-header {
+  display: flex;
+  flex: 0 0 auto; // should not shrink below height
+  flex-direction: row;
+
+  &.rbc-overflowing {
+    border-right: 1px solid $cell-border;
+  }
+
+  .rbc-rtl &.rbc-overflowing {
+    border-right-width: 0;
+    border-left: 1px solid $cell-border;
+  }
+
+  > .rbc-row:first-child {
+    border-bottom: 1px solid $cell-border;
+  }
+
+  > .rbc-row.rbc-row-resource {
+    border-bottom: 1px solid $cell-border;
+  }
+
+  // .rbc-gutter-cell {
+  //   flex: none;
+  // }
+
+  // > .rbc-gutter-cell + * {
+  //   width: 100%;
+  // }
+}
+
+.rbc-time-header-cell-single-day {
+  display: none;
+}
+
+.rbc-time-header-content {
+  flex: 1;
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  border-left: 1px solid $cell-border;
+
+  .rbc-rtl & {
+    border-left-width: 0;
+    border-right: 1px solid $cell-border;
+  }
+}
+
+.rbc-time-content {
+  display: flex;
+  flex: 1 0 0%;
+  align-items: flex-start;
+  width: 100%;
+  border-top: 2px solid $calendar-border;
+  overflow-y: auto;
+  position: relative;
+
+  > .rbc-time-gutter {
+    flex: none;
+  }
+
+  > * + * > * {
+    border-left: 1px solid $cell-border;
+  }
+
+  .rbc-rtl & > * + * > * {
+    border-left-width: 0;
+    border-right: 1px solid $cell-border;
+  }
+
+  > .rbc-day-slot {
+    width: 100%;
+    user-select: none;
+    -webkit-user-select: none;
+  }
+}
+
+.rbc-current-time-indicator {
+  position: absolute;
+  z-index: 3;
+  left: 0;
+  right: 0;
+  height: 1px;
+
+  background-color: $current-time-color;
+  pointer-events: none;
+}

--- a/src/sass/_partials/_toolbar.scss
+++ b/src/sass/_partials/_toolbar.scss
@@ -1,0 +1,104 @@
+$active-background: darken($btn-bg, 10%);
+$active-border: darken($btn-border, 12%);
+
+.rbc-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 10px;
+  font-size: 16px;
+
+  .rbc-toolbar-label {
+    flex-grow:1;
+    padding: 0 10px;
+    text-align: center;
+  }
+
+  & button {
+    color: $btn-color;
+    display: inline-block;
+    margin: 0;
+    text-align: center;
+    vertical-align: middle;
+    background: none;
+    background-image: none;
+    border: 1px solid $btn-border;
+    padding: .375rem 1rem;
+    border-radius: 4px;
+    line-height: normal;
+    white-space: nowrap;
+
+    &:active,
+    &.rbc-active {
+      background-image: none;
+      box-shadow: inset 0 3px 5px rgba(0,0,0,.125);
+      background-color: $active-background;
+      border-color: $active-border;
+
+      &:hover,
+      &:focus {
+        color: $btn-color;
+        background-color: darken($btn-bg, 17%);
+        border-color: darken($btn-border, 25%);
+      }
+    }
+
+    &:focus {
+      color: $btn-color;
+      background-color: $active-background;
+      border-color: $active-border;
+    }
+
+    &:hover {
+      color: $btn-color;
+      background-color: $active-background;
+          border-color: $active-border;
+    }
+  }
+}
+
+.rbc-btn-group {
+  display: inline-block;
+  white-space: nowrap;
+
+  > button:first-child:not(:last-child) {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  > button:last-child:not(:first-child) {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
+  .rbc-rtl & > button:first-child:not(:last-child) {
+    border-radius: 4px;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
+  .rbc-rtl & > button:last-child:not(:first-child) {
+    border-radius: 4px;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  > button:not(:first-child):not(:last-child) {
+    border-radius: 0;
+  }
+
+  button + button {
+    margin-left: -1px;
+  }
+
+  .rbc-rtl & button + button {
+    margin-left: 0;
+    margin-right: -1px;
+  }
+
+  & + &,
+  & + button {
+    margin-left: 10px;
+  }
+}

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -1,0 +1,48 @@
+%rbc-ellipsis {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+%rbc-abs-full {
+    overflow: hidden;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+}
+
+$out-of-range-color: lighten(#333, 40%);
+$out-of-range-bg-color: lighten(#333, 70%);
+
+$calendar-border: #DDD;
+$cell-border: #DDD;
+
+$border-color: #CCC;
+
+$segment-width: percentage(1 / 7);
+
+$time-selection-color: white;
+$time-selection-bg-color: rgba(0,0,0, .50);
+$date-selection-bg-color: rgba(0,0,0, .10);
+
+
+$event-bg: #3174ad;
+$event-border: darken(#3174ad, 10%);
+$event-outline: #3b99fc;
+$event-color: #fff;
+$event-border-radius: 5px;
+$event-padding: 2px 5px;
+$event-zindex: 4;
+
+$btn-color: #373a3c;
+$btn-bg: #fff;
+$btn-border: #ccc;
+
+$current-time-color: #74ad31;
+
+$rbc-css-prefix: 'rbc-i';
+
+$today-highlight-bg: #eaf6ff;

--- a/src/sass/calendar.scss
+++ b/src/sass/calendar.scss
@@ -1,0 +1,77 @@
+@import './variables';
+@import './_partials/reset';
+
+.rbc-calendar {
+  box-sizing: border-box;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.rbc-calendar *,
+.rbc-calendar *:before,
+.rbc-calendar *:after {
+  box-sizing: inherit;
+}
+
+.rbc-rtl {
+  direction: rtl;
+}
+
+.rbc-off-range {
+  color: $out-of-range-color;
+}
+
+.rbc-off-range-bg {
+  background: $out-of-range-bg-color;
+}
+
+.rbc-header {
+  overflow: hidden;
+  flex: 1 0 0%;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 0 3px;
+  text-align: center;
+  vertical-align: middle;
+  font-weight: bold;
+  font-size: 90%;
+  min-height: 0;
+  border-bottom: 1px solid $cell-border;
+
+  & + & {
+    border-left: 1px solid $cell-border;
+  }
+
+  .rbc-rtl & + & {
+    border-left-width: 0;
+    border-right: 1px solid $cell-border;
+  }
+
+  & > a {
+    &, &:active, &:visited {
+      color: inherit;
+      text-decoration: none;
+    }
+  }
+}
+
+.rbc-row-content {
+  position: relative;
+  user-select: none;
+  -webkit-user-select: none;
+  z-index: 4;
+}
+
+.rbc-today {
+  background-color: $today-highlight-bg;
+}
+
+
+@import './_partials/toolbar';
+@import './_partials/event';
+@import './_partials/month';
+@import './_partials/agenda';
+@import './_partials/time-grid';
+


### PR DESCRIPTION
I have added `scss` version of the styles. 

The reason I did this, because I prefer `sass` over `less`, therefore the project I intended to use this component, is purely based on `sass`, and using `node-sass`.

So with this `pr` users will be able to do `scss` import, such as: 

`import './path/to/calendar/style.css`