### PR TITLE
Broadcast initial view range on component mount

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "./dist/react-big-calendar.js": {
-    "bundled": 470853,
-    "minified": 153064,
-    "gzipped": 42298
+    "bundled": 455385,
+    "minified": 146083,
+    "gzipped": 41768
   },
   "./dist/react-big-calendar.min.js": {
-    "bundled": 413805,
-    "minified": 136004,
-    "gzipped": 38362
+    "bundled": 393407,
+    "minified": 127421,
+    "gzipped": 37548
   },
   "dist/react-big-calendar.esm.js": {
-    "bundled": 167523,
-    "minified": 80477,
-    "gzipped": 19800,
+    "bundled": 167179,
+    "minified": 80295,
+    "gzipped": 19803,
     "treeshaked": {
       "rollup": {
-        "code": 62050,
+        "code": 62031,
         "import_statements": 1470
       },
       "webpack": {
-        "code": 65556
+        "code": 65524
       }
     }
   }

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -956,6 +956,14 @@ class Calendar extends React.Component {
     this.handleRangeChange(date, ViewComponent)
   }
 
+  componentWillMount() {
+    const viewComponent = this.getView()
+    this.handleRangeChange(
+      this.props.date || this.props.getNow(),
+      viewComponent
+    )
+  }
+
   handleViewChange = view => {
     if (view !== this.props.view && isValidView(view, this.props)) {
       this.props.onView(view)


### PR DESCRIPTION
This addresses the FR made in Issues #1230. This will broadcast the initial view date range when the component mounts, if the developer has configured `onRangeChange`.