### PR TITLE
fix selecting events in mobile browsers

### DIFF
--- a/src/Selection.js
+++ b/src/Selection.js
@@ -341,7 +341,7 @@ class Selection {
 
     // Prevent emitting selectStart event until mouse is moved.
     // in Chrome on Windows, mouseMove event may be fired just after mouseDown event.
-    if (!old && !(w || h)) {
+    if (this.isClick(pageX, pageY) && !old && !(w || h)) {
       return
     }
 


### PR DESCRIPTION
This is a bug.
It was introduced in #884

on longpress range and therefore start and end variables were empty.

Fixed this by checking, whether the event is a Click.