### PR TITLE
Fix misplacement of current time indicator

### DIFF
--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -44,12 +44,18 @@ class DayColumn extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if (prevProps.isNow !== this.props.isNow) {
+    const getNowChanged = !dates.eq(
+      prevProps.getNow(),
+      this.props.getNow(),
+      'minutes'
+    )
+
+    if (prevProps.isNow !== this.props.isNow || getNowChanged) {
       this.clearTimeIndicatorInterval()
 
       if (this.props.isNow) {
         const tail =
-          this.props.getNow === this.props.getNow &&
+          !getNowChanged &&
           dates.eq(prevProps.date, this.props.date, 'minutes') &&
           prevState.timeIndicatorPosition === this.state.timeIndicatorPosition
 

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -48,9 +48,12 @@ class DayColumn extends React.Component {
       this.clearTimeIndicatorInterval()
 
       if (this.props.isNow) {
-        this.setTimeIndicatorPositionUpdateInterval(
+        const tail =
+          this.props.getNow === this.props.getNow &&
+          dates.eq(prevProps.date, this.props.date, 'minutes') &&
           prevState.timeIndicatorPosition === this.state.timeIndicatorPosition
-        )
+
+        this.setTimeIndicatorPositionUpdateInterval(tail)
       }
     }
   }


### PR DESCRIPTION
Hello,
It looked like PR for this issue (#1054) was abandoned and the bug still exists so I've decided to continue jdaberkow's work.
Also I've added check for `getNow` prop, because when you want to implement timezones you may have different `getNow` function depending on which timezone is selected. When user changes the timezone indicator should move to correct position for that timezone.