### PR TITLE
Adding missing props on slot select in Month view

### DIFF
--- a/src/Month.js
+++ b/src/Month.js
@@ -273,6 +273,8 @@ class MonthView extends React.Component {
       start: slots[0],
       end: slots[slots.length - 1],
       action: slotInfo.action,
+      bounds: slotInfo.bounds,
+      box: slotInfo.box
     })
   }
 


### PR DESCRIPTION
Pass the 'bounds' and 'box' props on slot select in Month view to the handler