### PR TITLE
Support point-in-time events in the Agenda view

### DIFF
--- a/examples/events.js
+++ b/examples/events.js
@@ -1,3 +1,5 @@
+const now = new Date()
+
 export default [
   {
     id: 0,
@@ -102,5 +104,11 @@ export default [
     title: 'Today',
     start: new Date(new Date().setHours(new Date().getHours() - 3)),
     end: new Date(new Date().setHours(new Date().getHours() + 3)),
+  },
+  {
+    id: 15,
+    title: 'Point in Time Event',
+    start: now,
+    end: now,
   },
 ]

--- a/src/Agenda.js
+++ b/src/Agenda.js
@@ -129,7 +129,9 @@ class Agenda extends React.Component {
     let start = accessors.start(event)
 
     if (!accessors.allDay(event)) {
-      if (dates.eq(start, end, 'day')) {
+      if (dates.eq(start, end)) {
+        label = localizer.format(start, 'agendaTimeFormat')
+      } else if (dates.eq(start, end, 'day')) {
         label = localizer.format({ start, end }, 'agendaTimeRangeFormat')
       } else if (dates.eq(day, start, 'day')) {
         label = localizer.format(start, 'agendaTimeFormat')


### PR DESCRIPTION
Some events may have the same start/end date/time, and are meant to represent point-in-time events, such as deadlines. These are not all day events, but they also should not be represented as `${startTime} - ${endTime}` since the values will be the same.

This will cause an event that is not marked as all day, and where the start and end are equal, to show as:

```js
// old
`${startTime} — ${endTime}` // 5:04 pm — 5:04 pm

// new
`${startTime}` // 5:04 pm
```