### PR TITLE
Make .babelrc be valid JSON

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,7 @@
 {
   "presets": ["jason"],
-  plugins: [
-    ['transform-react-remove-prop-types', { mode: 'wrap' }],
+  "plugins": [
+    ["transform-react-remove-prop-types", { "mode": "wrap" }]
   ],
   "env": {
     "esm": {


### PR DESCRIPTION
`.babelrc` is meant to be in JSON format, which requires double quoting key values and strings, and does not allow for trailing commas for the last item of lists or maps.