### PR TITLE
Allow for custom titles in the toolbar

### DIFF
--- a/examples/App.js
+++ b/examples/App.js
@@ -20,6 +20,7 @@ import Selectable from './demos/selectable'
 import Cultures from './demos/cultures'
 import Popup from './demos/popup'
 import Rendering from './demos/rendering'
+import CustomHeader from './demos/customHeader'
 import CustomView from './demos/customView'
 import Resource from './demos/resource'
 import DndResource from './demos/dndresource'
@@ -40,6 +41,7 @@ const EXAMPLES = {
   popup: 'Show more via a popup',
   timeslots: 'Custom Time Grids',
   rendering: 'Customized Component Rendering',
+  customHeader: 'Custom Calendar Headers',
   customView: 'Custom Calendar Views',
   resource: 'Resource Scheduling',
   dnd: 'Addon: Drag and drop',
@@ -73,6 +75,7 @@ class Example extends React.Component {
       cultures: Cultures,
       popup: Popup,
       rendering: Rendering,
+      customHeader: CustomHeader,
       customView: CustomView,
       resource: Resource,
       timeslots: Timeslots,

--- a/examples/demos/customHeader.js
+++ b/examples/demos/customHeader.js
@@ -1,6 +1,22 @@
 import React from 'react'
 import BigCalendar from 'react-big-calendar'
 import events from '../events'
+import { views } from '../../src/utils/constants'
+
+const getLabel = view => {
+  switch (view) {
+    case views.AGENDA:
+      return 'Custom Agenda Toolbar Title'
+    case views.DAY:
+      return 'Custom Day Toolbar Title'
+    case views.MONTH:
+      return 'Custom Month Toolbar Title'
+    case views.WEEK:
+      return 'Custom Week Toolbar Title'
+    case views.WORK_WEEK:
+      return 'Custom Work Week Toolbar Title'
+  }
+}
 
 let MyOtherNestedComponent = () => <div>NESTED COMPONENT</div>
 
@@ -22,6 +38,7 @@ let CustomHeader = ({ localizer }) => (
       week: { header: MyCustomHeader },
       month: { header: MyCustomHeader },
     }}
+    getLabel={getLabel}
   />
 )
 

--- a/src/Agenda.js
+++ b/src/Agenda.js
@@ -5,7 +5,7 @@ import getWidth from 'dom-helpers/query/width'
 import scrollbarSize from 'dom-helpers/util/scrollbarSize'
 
 import dates from './utils/dates'
-import { navigate } from './utils/constants'
+import { navigate, views } from './utils/constants'
 import { inRange } from './utils/eventLevels'
 import { isSelected } from './utils/selection'
 
@@ -218,8 +218,16 @@ Agenda.navigate = (date, action, { length = Agenda.defaultProps.length }) => {
   }
 }
 
-Agenda.title = (start, { length = Agenda.defaultProps.length, localizer }) => {
+Agenda.title = (
+  start,
+  { getLabel, length = Agenda.defaultProps.length, localizer }
+) => {
+  if (getLabel) {
+    return getLabel(views.AGENDA, start, length)
+  }
+
   let end = dates.add(start, length, 'day')
+
   return localizer.format({ start, end }, 'agendaHeaderFormat')
 }
 

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -186,7 +186,7 @@ class Calendar extends React.Component {
     /**
      * An array of resource objects that map events to a specific resource.
      * Resource objects, like events, can be any shape or have any properties,
-     * but should be uniquly identifiable via the `resourceIdAccessor`, as
+     * but should be uniquely identifiable via the `resourceIdAccessor`, as
      * well as a "title" or name as provided by the `resourceTitleAccessor` prop.
      */
     resources: PropTypes.arrayOf(PropTypes.object),
@@ -212,6 +212,18 @@ class Calendar extends React.Component {
      * @type {(func|string)}
      */
     resourceTitleAccessor: accessor,
+
+    /**
+     * Determines the label used in the toolbar. If this function is passed then
+     * the generated localizer (including any that used options from `formats`)
+     * will be given to the callback.
+     *
+     * @type {func}
+     * @param {'month'|'week'|'work_week'|'day'|'agenda'} view The current view
+     * @param {Date} date The current date/time
+     * @param {number} length The `length` prop
+     */
+    getLabel: PropTypes.func,
 
     /**
      * Determines the current date/time which is highlighted in the views.
@@ -753,6 +765,7 @@ class Calendar extends React.Component {
       context: this.getContext(this.props),
     }
   }
+
   componentWillReceiveProps(nextProps) {
     this.setState({ context: this.getContext(nextProps) })
   }
@@ -853,6 +866,7 @@ class Calendar extends React.Component {
       className,
       elementProps,
       date: current,
+      getLabel,
       getNow,
       length,
       showMultiDayTimes,
@@ -876,7 +890,7 @@ class Calendar extends React.Component {
     } = this.state.context
 
     let CalToolbar = components.toolbar || Toolbar
-    const label = View.title(current, { localizer, length })
+    const label = View.title(current, { getLabel, localizer, length })
 
     return (
       <div

--- a/src/Day.js
+++ b/src/Day.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 import dates from './utils/dates'
-import { navigate } from './utils/constants'
+import { navigate, views } from './utils/constants'
 import TimeGrid from './TimeGrid'
 
 class Day extends React.Component {
@@ -35,6 +35,12 @@ Day.navigate = (date, action) => {
   }
 }
 
-Day.title = (date, { localizer }) => localizer.format(date, 'dayHeaderFormat')
+Day.title = (date, { getLabel, length, localizer }) => {
+  if (getLabel) {
+    return getLabel(views.DAY, date, length)
+  }
+
+  return localizer.format(date, 'dayHeaderFormat')
+}
 
 export default Day

--- a/src/Month.js
+++ b/src/Month.js
@@ -274,7 +274,7 @@ class MonthView extends React.Component {
       end: slots[slots.length - 1],
       action: slotInfo.action,
       bounds: slotInfo.bounds,
-      box: slotInfo.box
+      box: slotInfo.box,
     })
   }
 
@@ -345,7 +345,12 @@ MonthView.navigate = (date, action) => {
   }
 }
 
-MonthView.title = (date, { localizer }) =>
-  localizer.format(date, 'monthHeaderFormat')
+MonthView.title = (date, { getLabel, length, localizer }) => {
+  if (getLabel) {
+    return getLabel(views.MONTH, date, length)
+  }
+
+  return localizer.format(date, 'monthHeaderFormat')
+}
 
 export default MonthView

--- a/src/Week.js
+++ b/src/Week.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import dates from './utils/dates'
-import { navigate } from './utils/constants'
+import { navigate, views } from './utils/constants'
 import TimeGrid from './TimeGrid'
 
 class Week extends React.Component {
@@ -40,8 +40,13 @@ Week.range = (date, { localizer }) => {
   return dates.range(start, end)
 }
 
-Week.title = (date, { localizer }) => {
+Week.title = (date, { getLabel, length, localizer }) => {
+  if (getLabel) {
+    return getLabel(views.WEEK, date, length)
+  }
+
   let [start, ...rest] = Week.range(date, { localizer })
+
   return localizer.format({ start, end: rest.pop() }, 'dayRangeHeaderFormat')
 }
 

--- a/src/WorkWeek.js
+++ b/src/WorkWeek.js
@@ -3,6 +3,7 @@ import React from 'react'
 
 import Week from './Week'
 import TimeGrid from './TimeGrid'
+import { views } from './utils/constants'
 
 function workWeekRange(date, options) {
   return Week.range(date, options).filter(
@@ -29,7 +30,11 @@ WorkWeek.range = workWeekRange
 
 WorkWeek.navigate = Week.navigate
 
-WorkWeek.title = (date, { localizer }) => {
+WorkWeek.title = (date, { getLabel, length, localizer }) => {
+  if (getLabel) {
+    return getLabel(views.WORK_WEEK, date, length)
+  }
+
   let [start, ...rest] = workWeekRange(date, { localizer })
 
   return localizer.format({ start, end: rest.pop() }, 'dayRangeHeaderFormat')


### PR DESCRIPTION
Currently, even when building a custom toolbar, the `label` prop passed to it is not controllable. Further, for someone who wants to modify just the `label`, building a custom toolbar component is overly complex.

This allows for the user to pass a new prop, `getLabel`, which allows for customizing the label passed to the toolbar. The prop is a function which is given access to the current date, the current view, and the view's length (when needed).

This also adds the `Custom Header` example to the examples list. This page existed but was not listed. This fixes that.