### PR TITLE
Fix: prevent un/mounting of date components

### DIFF
--- a/src/Month.js
+++ b/src/Month.js
@@ -36,7 +36,7 @@ class MonthView extends React.Component {
 
   componentWillReceiveProps({ date }) {
     this.setState({
-      needLimitMeasure: !dates.eq(date, this.props.date),
+      needLimitMeasure: !dates.eq(date, this.props.date, 'month'),
     })
   }
 
@@ -274,7 +274,7 @@ class MonthView extends React.Component {
       end: slots[slots.length - 1],
       action: slotInfo.action,
       bounds: slotInfo.bounds,
-      box: slotInfo.box
+      box: slotInfo.box,
     })
   }
 


### PR DESCRIPTION
I wanted to make a transition to date elements when they were selected, releasing that a couldn't get the `transition` property working. 

After some digging to my code and react-big-calendar code, I found that after selecting a date `DateContentRow` un&mount  their children components.

This happens due to the call of [this](https://github.com/intljusticemission/react-big-calendar/blob/master/src/DateContentRow.js#L121) `renderDummy` happens after setting `needLimitMeasure` to true in `Month.jsx` after the date is changed.

----------------------------

Prevent re-mount of DateContentRow children when date change in the same month
 * Prevent setting `needLimitMeasure` to true when the month of the date is not changed,
 in order to prevent unmounting and mounting of all the weeks' components.

 * Make it possible to add transition to the background of the event when
 implementing selection of date within the calendar.


