### PR TITLE
added a flag to determine if events should overlap

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -631,6 +631,11 @@ class Calendar extends React.Component {
        * An optional event time range for events that continue from another day
        */
       eventTimeRangeEndFormat: dateFormat,
+
+      /**
+       * Determines if meetings should overlap
+       */
+      overlapMeetings: PropTypes.bool
     }),
 
     /**
@@ -746,6 +751,8 @@ class Calendar extends React.Component {
 
     longPressThreshold: 250,
     getNow: () => new Date(),
+
+    overlapMeetings: true
   }
 
   constructor(...args) {

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -635,7 +635,7 @@ class Calendar extends React.Component {
       /**
        * Determines if meetings should overlap
        */
-      overlapMeetings: PropTypes.bool
+      overlapEvents: PropTypes.bool,
     }),
 
     /**
@@ -752,7 +752,7 @@ class Calendar extends React.Component {
     longPressThreshold: 250,
     getNow: () => new Date(),
 
-    overlapMeetings: true
+    overlapEvents: true,
   }
 
   constructor(...args) {

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -177,6 +177,7 @@ class DayColumn extends React.Component {
       components,
       step,
       timeslots,
+      overlapMeetings
     } = this.props
 
     const { slotMetrics } = this
@@ -187,6 +188,7 @@ class DayColumn extends React.Component {
       accessors,
       slotMetrics,
       minimumStartDifference: Math.ceil((step * timeslots) / 2),
+      overlapMeetings
     })
 
     return styledEvents.map(({ event, style }, idx) => {
@@ -391,6 +393,8 @@ DayColumn.propTypes = {
   className: PropTypes.string,
   dragThroughEvents: PropTypes.bool,
   resource: PropTypes.any,
+
+  overlapMeetings: PropTypes.bool
 }
 
 DayColumn.defaultProps = {

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -177,7 +177,7 @@ class DayColumn extends React.Component {
       components,
       step,
       timeslots,
-      overlapMeetings
+      overlapEvents,
     } = this.props
 
     const { slotMetrics } = this
@@ -188,7 +188,7 @@ class DayColumn extends React.Component {
       accessors,
       slotMetrics,
       minimumStartDifference: Math.ceil((step * timeslots) / 2),
-      overlapMeetings
+      overlapEvents,
     })
 
     return styledEvents.map(({ event, style }, idx) => {
@@ -394,7 +394,7 @@ DayColumn.propTypes = {
   dragThroughEvents: PropTypes.bool,
   resource: PropTypes.any,
 
-  overlapMeetings: PropTypes.bool
+  overlapEvents: PropTypes.bool,
 }
 
 DayColumn.defaultProps = {

--- a/src/utils/DayEventLayout.js
+++ b/src/utils/DayEventLayout.js
@@ -1,7 +1,7 @@
 import sortBy from 'lodash/sortBy'
 
 class Event {
-  constructor(data, { accessors, slotMetrics }) {
+  constructor(data, { accessors, slotMetrics, overlapMeetings }) {
     const {
       start,
       startDate,
@@ -18,6 +18,7 @@ class Event {
     this.top = top
     this.height = height
     this.data = data
+    this.overlapMeetings = overlapMeetings
   }
 
   /**
@@ -53,6 +54,8 @@ class Event {
    * overlapping effect.
    */
   get width() {
+    if (!this.overlapMeetings) return this._width
+
     const noOverlap = this._width
     const overlap = Math.min(100, this._width * 1.7)
 
@@ -133,11 +136,12 @@ function getStyledEvents({
   minimumStartDifference,
   slotMetrics,
   accessors,
+  overlapMeetings
 }) {
   // Create proxy events and order them so that we don't have
   // to fiddle with z-indexes.
   const proxies = events.map(
-    event => new Event(event, { slotMetrics, accessors })
+    event => new Event(event, { slotMetrics, accessors, overlapMeetings })
   )
   const eventsInRenderOrder = sortByRender(proxies)
 

--- a/src/utils/DayEventLayout.js
+++ b/src/utils/DayEventLayout.js
@@ -1,7 +1,7 @@
 import sortBy from 'lodash/sortBy'
 
 class Event {
-  constructor(data, { accessors, slotMetrics, overlapMeetings }) {
+  constructor(data, { accessors, slotMetrics, overlapEvents }) {
     const {
       start,
       startDate,
@@ -18,7 +18,7 @@ class Event {
     this.top = top
     this.height = height
     this.data = data
-    this.overlapMeetings = overlapMeetings
+    this.overlapEvents = overlapEvents
   }
 
   /**
@@ -54,7 +54,7 @@ class Event {
    * overlapping effect.
    */
   get width() {
-    if (!this.overlapMeetings) return this._width
+    if (!this.overlapEvents) return this._width
 
     const noOverlap = this._width
     const overlap = Math.min(100, this._width * 1.7)
@@ -136,12 +136,12 @@ function getStyledEvents({
   minimumStartDifference,
   slotMetrics,
   accessors,
-  overlapMeetings
+  overlapEvents,
 }) {
   // Create proxy events and order them so that we don't have
   // to fiddle with z-indexes.
   const proxies = events.map(
-    event => new Event(event, { slotMetrics, accessors, overlapMeetings })
+    event => new Event(event, { slotMetrics, accessors, overlapEvents })
   )
   const eventsInRenderOrder = sortByRender(proxies)
 

--- a/test/utils/DayEventLayout.test.js
+++ b/test/utils/DayEventLayout.test.js
@@ -17,6 +17,7 @@ describe('getStyledEvents', () => {
           accessors,
           slotMetrics,
           minimumStartDifference: 10,
+          overlapMeetings: true
         })
         const results = styledEvents.map(result => ({
           width: Math.floor(result.style.width),

--- a/test/utils/DayEventLayout.test.js
+++ b/test/utils/DayEventLayout.test.js
@@ -17,7 +17,7 @@ describe('getStyledEvents', () => {
           accessors,
           slotMetrics,
           minimumStartDifference: 10,
-          overlapMeetings: true
+          overlapEvents: true,
         })
         const results = styledEvents.map(result => ({
           width: Math.floor(result.style.width),


### PR DESCRIPTION
fixes #1060 

I think this solves this issue of allowing an optional flag for overlapping meetings. This fix only provides a global flag for all events in the calendar. I am not sure there is a need to have it on a resource level also.