### PR TITLE
fix: change tooltipAccessor key to 'tooltip' from 'title'

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -735,7 +735,7 @@ class Calendar extends React.Component {
     drilldownView: views.DAY,
 
     titleAccessor: 'title',
-    tooltipAccessor: 'title',
+    tooltipAccessor: 'tooltip',
     allDayAccessor: 'allDay',
     startAccessor: 'start',
     endAccessor: 'end',


### PR DESCRIPTION
Events tooltip was from title of them. Changed key of tooltipAccessor to 'tooltip' for correct work.