### PR TITLE
Make last slot of day selectable

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,0 +1,1 @@
+import '@storybook/addon-actions/register'

--- a/src/Selection.js
+++ b/src/Selection.js
@@ -301,16 +301,16 @@ class Selection {
       return this.emit('reset')
     }
 
-    if (!inRoot) {
-      return this.emit('reset')
-    }
+    // User drag-clicked in the Selectable area
+    if (!click) return this.emit('select', bounds)
 
     if (click && inRoot) {
       return this._handleClickEvent(e)
     }
 
-    // User drag-clicked in the Selectable area
-    if (!click) return this.emit('select', bounds)
+    if (!inRoot) {
+      return this.emit('reset')
+    }
   }
 
   _handleClickEvent(e) {


### PR DESCRIPTION
Drag-click events that ended on the last slot of the day would not fire `onSelectSlot`.