### PR TITLE
fix: update time indicator position if min prop changes

### DIFF
--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -61,6 +61,11 @@ class DayColumn extends React.Component {
 
         this.setTimeIndicatorPositionUpdateInterval(tail)
       }
+    } else if (
+      this.props.isNow &&
+      !dates.eq(prevProps.min, this.props.min, 'minutes')
+    ) {
+      this.positionTimeIndicator()
     }
   }
 


### PR DESCRIPTION
When changing the `min` prop, the current time indicator is not re-positioned and therefore shows at the wrong place.

demonstration: https://codesandbox.io/s/y241x9njq1