### PR TITLE
Fix drag cancelation for month view

### DIFF
--- a/src/addons/dragAndDrop/WeekWrapper.js
+++ b/src/addons/dragAndDrop/WeekWrapper.js
@@ -221,6 +221,11 @@ class WeekWrapper extends React.Component {
     })
 
     selector.on('click', () => this.context.draggable.onEnd(null))
+
+    selector.on('reset', () => {
+      this.reset()
+      this.context.draggable.onEnd(null)
+    })
   }
 
   handleInteractionEnd = () => {


### PR DESCRIPTION
This is same fix as already done for day and week views done in #1119 done for month view.

* Fix dropping an event out of month view bounds leaving the calendar in an intermediate state (no listener on reset)