### PR TITLE
fix(addons): do not cut end while dragging multiday event

### DIFF
--- a/src/addons/dragAndDrop/EventContainerWrapper.js
+++ b/src/addons/dragAndDrop/EventContainerWrapper.js
@@ -94,7 +94,7 @@ class EventContainerWrapper extends React.Component {
       'minutes'
     )
 
-    this.update(event, slotMetrics.getRange(currentSlot, end))
+    this.update(event, slotMetrics.getRange(currentSlot, end, false, true))
   }
 
   handleResize(point, boundaryBox) {

--- a/src/utils/TimeSlots.js
+++ b/src/utils/TimeSlots.js
@@ -124,9 +124,11 @@ export function getSlotMetrics({ min: start, max: end, step, timeslots }) {
       return dates.gt(dates.merge(end, date), end, 'minutes')
     },
 
-    getRange(rangeStart, rangeEnd) {
-      rangeStart = dates.min(end, dates.max(start, rangeStart))
-      rangeEnd = dates.min(end, dates.max(start, rangeEnd))
+    getRange(rangeStart, rangeEnd, ignoreMin, ignoreMax) {
+      if (!ignoreMin)
+        rangeStart = dates.min(end, dates.max(start, rangeStart))
+      if (!ignoreMax)
+        rangeEnd = dates.min(end, dates.max(start, rangeEnd))
 
       const rangeStartMin = positionFromDate(rangeStart)
       const rangeEndMin = positionFromDate(rangeEnd)


### PR DESCRIPTION
Tries to fix issue #1105.
Added options to ignore timeslot start or end so day is not cut to the end of current day during DnD move.
Used only in DnD handleMove - rest remains as before.
Only end date is ignored - tested, worked ok. 
When start date was ignored it causes some issues slot not being rendered in correct slot sometimes.

Wasn't sure about names, so feel free to comment :) 