### PR TITLE
Remove prop-types-extra

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "./dist/react-big-calendar.js": {
-    "bundled": 561903,
-    "minified": 171545,
-    "gzipped": 50435
+    "bundled": 560715,
+    "minified": 171082,
+    "gzipped": 50325
   },
   "./dist/react-big-calendar.min.js": {
-    "bundled": 498126,
-    "minified": 152147,
-    "gzipped": 45902
+    "bundled": 496938,
+    "minified": 151688,
+    "gzipped": 45761
   },
   "dist/react-big-calendar.esm.js": {
-    "bundled": 169800,
-    "minified": 81627,
-    "gzipped": 20102,
+    "bundled": 169709,
+    "minified": 81558,
+    "gzipped": 20076,
     "treeshaked": {
       "rollup": {
-        "code": 63039,
-        "import_statements": 1418
+        "code": 62946,
+        "import_statements": 1378
       },
       "webpack": {
-        "code": 66506
+        "code": 66385
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -128,7 +128,6 @@
     "lodash": "^4.17.11",
     "memoize-one": "^4.0.3",
     "prop-types": "^15.6.2",
-    "prop-types-extra": "^1.1.0",
     "react-overlays": "^1.2.0",
     "uncontrollable": "^6.0.0",
     "warning": "^4.0.2"

--- a/src/utils/propTypes.js
+++ b/src/utils/propTypes.js
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types'
-import all from 'prop-types-extra/lib/all'
 import { views as Views } from './constants'
 
 let viewNames = Object.keys(Views).map(k => Views[k])
@@ -27,19 +26,16 @@ export let dateRangeFormat = PropTypes.func
  * }}
  * ```
  */
+
 export let views = PropTypes.oneOfType([
   PropTypes.arrayOf(PropTypes.oneOf(viewNames)),
-  all(PropTypes.object, (props, name, ...args) => {
-    let prop = props[name],
-      err
-
-    Object.keys(prop).every(key => {
-      let isBuiltinView =
-        viewNames.indexOf(key) !== -1 && typeof prop[key] === 'boolean'
-
-      return isBuiltinView || !(err = PropTypes.elementType(prop, key, ...args))
-    })
-
-    return err || null
+  PropTypes.objectOf((prop, key, ...args) => {
+    let isBuiltinView =
+      viewNames.indexOf(key) !== -1 && typeof prop[key] === 'boolean'
+    if (isBuiltinView) {
+      return null
+    } else {
+      return PropTypes.elementType(prop, key, ...args)
+    }
   }),
 ])


### PR DESCRIPTION
I found `all(object, customHandler)` can be replaced with
`objectOf(customHandler)` so we may drop prop-types-extra package.

There is still usage in react-overlays. Gonna send a PR too.