### PR TITLE
fix: rtl incorrectly named or not propagated

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -878,7 +878,7 @@ class Calendar extends React.Component {
     return (
       <div
         {...elementProps}
-        className={cn(className, 'rbc-calendar', props.rtl && 'rbc-is-rtl')}
+        className={cn(className, 'rbc-calendar', props.rtl && 'rbc-rtl')}
         style={style}
       >
         {toolbar && (

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -174,7 +174,7 @@ class DayColumn extends React.Component {
   renderEvents = () => {
     let {
       events,
-      rtl: isRtl,
+      rtl,
       selected,
       accessors,
       localizer,
@@ -219,7 +219,7 @@ class DayColumn extends React.Component {
           label={label}
           key={'evt_' + idx}
           getters={getters}
-          isRtl={isRtl}
+          rtl={rtl}
           components={components}
           continuesEarlier={continuesEarlier}
           continuesLater={continuesLater}

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -142,6 +142,7 @@ export default class TimeGrid extends Component {
       events,
       range,
       width,
+      rtl,
       selected,
       getNow,
       resources,
@@ -192,6 +193,7 @@ export default class TimeGrid extends Component {
           range={range}
           events={allDayEvents}
           width={width}
+          rtl={rtl}
           getNow={getNow}
           localizer={localizer}
           selected={selected}

--- a/src/TimeGridEvent.js
+++ b/src/TimeGridEvent.js
@@ -8,7 +8,7 @@ function TimeGridEvent(props) {
     className,
     event,
     accessors,
-    isRtl,
+    rtl,
     selected,
     label,
     continuesEarlier,
@@ -44,7 +44,7 @@ function TimeGridEvent(props) {
           ...userProps.style,
           top: `${top}%`,
           height: `${height}%`,
-          [isRtl ? 'right' : 'left']: `${Math.max(0, xOffset)}%`,
+          [rtl ? 'right' : 'left']: `${Math.max(0, xOffset)}%`,
           width: `${width}%`,
         }}
         title={

--- a/src/less/time-column.less
+++ b/src/less/time-column.less
@@ -39,7 +39,7 @@
     margin-right: 10px;
     top: 0;
 
-    &.rbc-is-rtl {
+    &.rbc-rtl {
       left: 10px;
       right: 0;
     }

--- a/src/sass/time-column.scss
+++ b/src/sass/time-column.scss
@@ -38,7 +38,7 @@
     margin-right: 10px;
     top: 0;
 
-    &.rbc-is-rtl {
+    &.rbc-rtl {
       left: 10px;
       right: 0;
     }


### PR DESCRIPTION
During some previous refactoring rtl was on some places renamed to `isRtl` or forgotten to propagate, causing it to not work at all - css was ignored.

I've reverted back to `rtl` notation as it common word already used in styles and in documentation as well.

