### PR TITLE
chore: remove unused eventOffset prop

### DIFF
--- a/examples/demos/customView.js
+++ b/examples/demos/customView.js
@@ -11,7 +11,7 @@ class MyWeek extends React.Component {
     let { date } = this.props
     let range = MyWeek.range(date)
 
-    return <TimeGrid {...this.props} range={range} eventOffset={15} />
+    return <TimeGrid {...this.props} range={range} />
   }
 }
 

--- a/src/Day.js
+++ b/src/Day.js
@@ -10,7 +10,7 @@ class Day extends React.Component {
     let { date, ...props } = this.props
     let range = Day.range(date)
 
-    return <TimeGrid {...props} range={range} eventOffset={10} />
+    return <TimeGrid {...props} range={range} />
   }
 }
 

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -385,7 +385,6 @@ DayColumn.propTypes = {
 
   selected: PropTypes.object,
   selectable: PropTypes.oneOf([true, false, 'ignoreEvents']),
-  eventOffset: PropTypes.number,
   longPressThreshold: PropTypes.number,
 
   onSelecting: PropTypes.func,

--- a/src/Week.js
+++ b/src/Week.js
@@ -9,7 +9,7 @@ class Week extends React.Component {
     let { date, ...props } = this.props
     let range = Week.range(date, this.props)
 
-    return <TimeGrid {...props} range={range} eventOffset={15} />
+    return <TimeGrid {...props} range={range} />
   }
 }
 

--- a/src/WorkWeek.js
+++ b/src/WorkWeek.js
@@ -15,7 +15,7 @@ class WorkWeek extends React.Component {
     let { date, ...props } = this.props
     let range = workWeekRange(date, this.props)
 
-    return <TimeGrid {...props} range={range} eventOffset={15} />
+    return <TimeGrid {...props} range={range} />
   }
 }
 


### PR DESCRIPTION
`eventOffset` was introduced in 8f7055a and doesn't seem to be used since c3493b4.