### PR TITLE
Fix errors on moving events or clicking slots in dndOutsideSource example

### DIFF
--- a/examples/demos/dndOutsideSource.js
+++ b/examples/demos/dndOutsideSource.js
@@ -162,7 +162,6 @@ class Dnd extends React.Component {
           resizable
           onEventResize={this.resizeEvent}
           onSelectSlot={this.newEvent}
-          onD
           defaultView={Views.MONTH}
           defaultDate={new Date(2015, 3, 12)}
         />

--- a/examples/demos/dndOutsideSource.js
+++ b/examples/demos/dndOutsideSource.js
@@ -2,7 +2,6 @@ import React from 'react'
 import events from '../events'
 import { Calendar, Views } from 'react-big-calendar'
 import withDragAndDrop from 'react-big-calendar/lib/addons/dragAndDrop'
-import Layout from 'react-tackle-box/Layout'
 import Card from '../Card'
 
 import 'react-big-calendar/lib/addons/dragAndDrop/styles.scss'

--- a/examples/demos/dndOutsideSource.js
+++ b/examples/demos/dndOutsideSource.js
@@ -101,7 +101,7 @@ class Dnd extends React.Component {
     let newId = Math.max(...idList) + 1
     let hour = {
       id: newId,
-      title: event.title,
+      title: event.title || window.prompt('New Event name'),
       allDay: event.isAllDay,
       start: event.start,
       end: event.end,

--- a/examples/demos/dndOutsideSource.js
+++ b/examples/demos/dndOutsideSource.js
@@ -56,7 +56,7 @@ class Dnd extends React.Component {
     this.newEvent(event)
   }
 
-  moveEvent({ event, start, end, isAllDay: droppedOnAllDaySlot }) {
+  moveEvent = ({ event, start, end, isAllDay: droppedOnAllDaySlot }) => {
     const { events } = this.state
 
     const idx = events.indexOf(event)

--- a/examples/demos/dndOutsideSource.js
+++ b/examples/demos/dndOutsideSource.js
@@ -96,7 +96,7 @@ class Dnd extends React.Component {
     //alert(`${event.title} was resized to ${start}-${end}`)
   }
 
-  newEvent(event) {
+  newEvent = event => {
     let idList = this.state.events.map(a => a.id)
     let newId = Math.max(...idList) + 1
     let hour = {


### PR DESCRIPTION
- Fix errors on moving events or clicking slots (0eb66b0, [`51f957a`](https://github.com/intljusticemission/react-big-calendar/commit/51f957a5a475da9a7292ec944c134fd48dec968e))
- Tweaks a behavior on adding a new event by clicking a slot (55f7b62)
- Clean up (8729128, d1c135a)