### PR TITLE
feat(dnd): add preview of an item inside cell while dragging

### DIFF
--- a/examples/demos/dndOutsideSource.js
+++ b/examples/demos/dndOutsideSource.js
@@ -21,11 +21,22 @@ class Dnd extends React.Component {
         item1: 0,
         item2: 0,
       },
+      displayDragItemInCell: true,
     }
   }
 
-  handleDragStart = name => {
-    this.setState({ draggedEvent: name })
+  handleDragStart = event => {
+    this.setState({ draggedEvent: event })
+  }
+
+  handleDisplayDragItemInCell = () => {
+    this.setState({
+      displayDragItemInCell: !this.state.displayDragItemInCell,
+    })
+  }
+
+  dragFromOutsideItem = () => {
+    return this.state.draggedEvent
   }
 
   customOnDragOver = event => {
@@ -43,14 +54,14 @@ class Dnd extends React.Component {
   onDropFromOutside = ({ start, end, allDay }) => {
     const { draggedEvent, counters } = this.state
     const event = {
-      title: formatName(draggedEvent, counters[draggedEvent]),
+      title: formatName(draggedEvent.name, counters[draggedEvent.name]),
       start,
       end,
       isAllDay: allDay,
     }
     const updatedCounters = {
       ...counters,
-      [draggedEvent]: counters[draggedEvent] + 1,
+      [draggedEvent.name]: counters[draggedEvent.name] + 1,
     }
     this.setState({ draggedEvent: null, counters: updatedCounters })
     this.newEvent(event)
@@ -114,16 +125,35 @@ class Dnd extends React.Component {
   render() {
     return (
       <div>
-        <Card
-          className="examples--header"
-          style={{
-            display: 'flex',
-            justifyContent: 'center',
-            flexWrap: 'wrap',
-          }}
-        >
-          <h4 style={{ color: 'gray', width: '100%' }}>Outside Drag Sources</h4>
-          {Object.entries(this.state.counters).map(([name, count]) => (
+        <Card className="examples--header" style={{ display: 'flex' }}>
+          <div
+            style={{
+              display: 'flex',
+              flex: 1,
+              justifyContent: 'center',
+              flexWrap: 'wrap',
+            }}
+          >
+            <h4 style={{ color: 'gray', width: '100%' }}>
+              Outside Drag Sources
+            </h4>
+            {Object.entries(this.state.counters).map(([name, count]) => (
+              <div
+                style={{
+                  border: '2px solid gray',
+                  borderRadius: '4px',
+                  width: '100px',
+                  margin: '10px',
+                }}
+                draggable="true"
+                key={name}
+                onDragStart={() =>
+                  this.handleDragStart({ title: formatName(name, count), name })
+                }
+              >
+                {formatName(name, count)}
+              </div>
+            ))}
             <div
               style={{
                 border: '2px solid gray',
@@ -133,23 +163,22 @@ class Dnd extends React.Component {
               }}
               draggable="true"
               key={name}
-              onDragStart={() => this.handleDragStart(name)}
+              onDragStart={() => this.handleDragStart('undroppable')}
             >
-              {formatName(name, count)}
+              Draggable but not for calendar.
             </div>
-          ))}
-          <div
-            style={{
-              border: '2px solid gray',
-              borderRadius: '4px',
-              width: '100px',
-              margin: '10px',
-            }}
-            draggable="true"
-            key={name}
-            onDragStart={() => this.handleDragStart('undroppable')}
-          >
-            Draggable but not for calendar.
+          </div>
+
+          <div>
+            <label>
+              <input
+                style={{ marginRight: 5 }}
+                type="checkbox"
+                checked={this.state.displayDragItemInCell}
+                onChange={this.handleDisplayDragItemInCell}
+              />
+              Display dragged item in cell while dragging over
+            </label>
           </div>
         </Card>
         <DragAndDropCalendar
@@ -157,6 +186,9 @@ class Dnd extends React.Component {
           localizer={this.props.localizer}
           events={this.state.events}
           onEventDrop={this.moveEvent}
+          dragFromOutsideItem={
+            this.state.displayDragItemInCell ? this.dragFromOutsideItem : null
+          }
           onDropFromOutside={this.onDropFromOutside}
           onDragOver={this.customOnDragOver}
           resizable

--- a/src/Selection.js
+++ b/src/Selection.js
@@ -56,6 +56,9 @@ class Selection {
     this._handleTerminatingEvent = this._handleTerminatingEvent.bind(this)
     this._keyListener = this._keyListener.bind(this)
     this._dropFromOutsideListener = this._dropFromOutsideListener.bind(this)
+    this._dragOverFromOutsideListener = this._dragOverFromOutsideListener.bind(
+      this
+    )
 
     // Fixes an iOS 10 bug where scrolling could not be prevented on the window.
     // https://github.com/metafizzy/flickity/issues/457#issuecomment-254501356
@@ -69,6 +72,10 @@ class Selection {
     this._onDropFromOutsideListener = addEventListener(
       'drop',
       this._dropFromOutsideListener
+    )
+    this._onDragOverfromOutisde = addEventListener(
+      'dragover',
+      this._dragOverFromOutsideListener
     )
     this._addInitialEventListener()
   }
@@ -105,6 +112,7 @@ class Selection {
     this._onMoveListener && this._onMoveListener.remove()
     this._onKeyUpListener && this._onKeyUpListener.remove()
     this._onKeyDownListener && this._onKeyDownListener.remove()
+    this._onDropFromOutsideListener && this._onDragOverfromOutisde.remove()
   }
 
   isSelected(node) {
@@ -198,6 +206,19 @@ class Selection {
     const { pageX, pageY, clientX, clientY } = getEventCoordinates(e)
 
     this.emit('dropFromOutside', {
+      x: pageX,
+      y: pageY,
+      clientX: clientX,
+      clientY: clientY,
+    })
+
+    e.preventDefault()
+  }
+
+  _dragOverFromOutsideListener(e) {
+    const { pageX, pageY, clientX, clientY } = getEventCoordinates(e)
+
+    this.emit('dragOverFromOutside', {
       x: pageX,
       y: pageY,
       clientX: clientX,

--- a/src/addons/dragAndDrop/EventContainerWrapper.js
+++ b/src/addons/dragAndDrop/EventContainerWrapper.js
@@ -34,6 +34,7 @@ class EventContainerWrapper extends React.Component {
       onDropFromOutside: PropTypes.func,
       onBeginAction: PropTypes.func,
       dragAndDropAction: PropTypes.object,
+      dragFromOutsideItem: PropTypes.func,
     }),
   }
 
@@ -164,6 +165,14 @@ class EventContainerWrapper extends React.Component {
       const bounds = getBoundsForNode(node)
 
       if (!pointInColumn(bounds, point)) return
+
+      this.handleDropFromOutside(point, bounds)
+    })
+
+    selector.on('dragOver', point => {
+      if (!this.context.draggable.dragFromOutsideItem) return
+
+      const bounds = getBoundsForNode(node)
 
       this.handleDropFromOutside(point, bounds)
     })

--- a/src/addons/dragAndDrop/WeekWrapper.js
+++ b/src/addons/dragAndDrop/WeekWrapper.js
@@ -39,6 +39,7 @@ class WeekWrapper extends React.Component {
       dragAndDropAction: PropTypes.object,
       onDropFromOutside: PropTypes.func,
       onBeginAction: PropTypes.func,
+      dragFromOutsideItem: PropTypes.func,
     }),
   }
 
@@ -78,8 +79,8 @@ class WeekWrapper extends React.Component {
     this.setState({ segment })
   }
 
-  handleMove = ({ x, y }, node) => {
-    const { event } = this.context.draggable.dragAndDropAction
+  handleMove = ({ x, y }, node, draggedEvent) => {
+    const { event = draggedEvent } = this.context.draggable.dragAndDropAction
     const metrics = this.props.slotMetrics
     const { accessors } = this.props
 
@@ -120,6 +121,16 @@ class WeekWrapper extends React.Component {
       end: dates.add(start, 1, 'day'),
       allDay: false,
     })
+  }
+
+  handleDragOverFromOutside = ({ x, y }, node) => {
+    if (!this.context.draggable.dragFromOutsideItem) return
+
+    this.handleMove(
+      { x, y },
+      node,
+      this.context.draggable.dragFromOutsideItem()
+    )
   }
 
   handleResize(point, node) {
@@ -218,6 +229,14 @@ class WeekWrapper extends React.Component {
       if (!pointInBox(bounds, point)) return
 
       this.handleDropFromOutside(point, bounds)
+    })
+
+    selector.on('dragOverFromOutside', point => {
+      if (!this.context.draggable.dragFromOutsideItem) return
+
+      const bounds = getBoundsForNode(node)
+
+      this.handleDragOverFromOutside(point, bounds)
     })
 
     selector.on('click', () => this.context.draggable.onEnd(null))

--- a/src/addons/dragAndDrop/withDragAndDrop.js
+++ b/src/addons/dragAndDrop/withDragAndDrop.js
@@ -72,6 +72,8 @@ export default function withDragAndDrop(Calendar) {
       onDragOver: PropTypes.func,
       onDropFromOutside: PropTypes.func,
 
+      dragFromOutsideItem: PropTypes.func,
+
       draggableAccessor: accessor,
       resizableAccessor: accessor,
 
@@ -100,6 +102,7 @@ export default function withDragAndDrop(Calendar) {
         onEnd: PropTypes.func,
         onBeginAction: PropTypes.func,
         onDropFromOutside: PropTypes.fun,
+        dragFromOutsideItem: PropTypes.fun,
         draggableAccessor: accessor,
         resizableAccessor: accessor,
         dragAndDropAction: PropTypes.object,
@@ -127,6 +130,7 @@ export default function withDragAndDrop(Calendar) {
           onEnd: this.handleInteractionEnd,
           onBeginAction: this.handleBeginAction,
           onDropFromOutside: this.props.onDropFromOutside,
+          dragFromOutsideItem: this.props.dragFromOutsideItem,
           draggableAccessor: this.props.draggableAccessor,
           resizableAccessor: this.props.resizableAccessor,
           dragAndDropAction: this.state,


### PR DESCRIPTION
While dragging over a cell it might be useful to see placeholder for an item where it will be inserted as soon we drop it.

**Please see example below**

![drag](https://user-images.githubusercontent.com/43654788/60168708-fa216480-980d-11e9-89b5-ee44a969a50a.gif)
