### PR TITLE
Downgrade date-arithmetic

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   "dependencies": {
     "@babel/runtime": "^7.1.5",
     "classnames": "^2.2.6",
-    "date-arithmetic": "^4.0.1",
+    "date-arithmetic": "^3.1.0",
     "dom-helpers": "^3.4.0",
     "invariant": "^2.2.4",
     "lodash": "^4.17.11",


### PR DESCRIPTION
Date add minutes broken in date-arithmetic https://github.com/jquense/date-math/issues/18
Issue will cause trouble with drag and drop in month view, when event is longer than a day.