### PR TITLE
Add flex-base units to support IE11

### DIFF
--- a/src/less/agenda.less
+++ b/src/less/agenda.less
@@ -3,7 +3,7 @@
 .rbc-agenda-view {
   display: flex;
   flex-direction: column;
-  flex: 1 0 0;
+  flex: 1 0 0%;
   overflow: auto;
 
   table.rbc-agenda-table {

--- a/src/less/month.less
+++ b/src/less/month.less
@@ -34,7 +34,7 @@
   border: 1px solid @calendar-border;
   display: flex;
   flex-direction: column;
-  flex: 1 0 0;
+  flex: 1 0 0%;
   width: 100%;
   user-select: none;
   -webkit-user-select: none;
@@ -51,7 +51,7 @@
   display: flex;
   position: relative;
   flex-direction: column;
-  flex: 1 0 0; // postcss will remove the 0px here hence the duplication below
+  flex: 1 0 0%; // postcss will remove the 0px here hence the duplication below
   flex-basis: 0px;
   overflow: hidden;
 
@@ -63,7 +63,7 @@
 }
 
 .rbc-date-cell {
-  flex: 1 1 0;
+  flex: 1 1 0%;
   min-width: 0;
   padding-right: 5px;
   text-align: right;
@@ -84,7 +84,7 @@
   &:extend(.rbc-abs-full);
   display: flex;
   flex-direction: row;
-  flex: 1 0 0;
+  flex: 1 0 0%;
   overflow: hidden;
 }
 

--- a/src/less/time-column.less
+++ b/src/less/time-column.less
@@ -64,7 +64,7 @@
 
   .rbc-event-content {
     width: 100%;
-    flex: 1 1 0;
+    flex: 1 1 0%;
     word-wrap: break-word;
     line-height: 1;
     height: 100%;
@@ -93,7 +93,7 @@
 
   .rbc-time-header-content {
     min-width: auto;
-    flex: 1 0 0;
+    flex: 1 0 0%;
     flex-basis: 0px;
   }
 

--- a/src/sass/agenda.scss
+++ b/src/sass/agenda.scss
@@ -3,7 +3,7 @@
 .rbc-agenda-view {
   display: flex;
   flex-direction: column;
-  flex: 1 0 0;
+  flex: 1 0 0%;
   overflow: auto;
 
   table.rbc-agenda-table {

--- a/src/sass/month.scss
+++ b/src/sass/month.scss
@@ -33,7 +33,7 @@
   border: 1px solid $calendar-border;
   display: flex;
   flex-direction: column;
-  flex: 1 0 0;
+  flex: 1 0 0%;
   width: 100%;
   user-select: none;
   -webkit-user-select: none;
@@ -50,7 +50,7 @@
   display: flex;
   position: relative;
   flex-direction: column;
-  flex: 1 0 0; // postcss will remove the 0px here hence the duplication below
+  flex: 1 0 0%; // postcss will remove the 0px here hence the duplication below
   flex-basis: 0px;
   overflow: hidden;
 
@@ -62,7 +62,7 @@
 }
 
 .rbc-date-cell {
-  flex: 1 1 0;
+  flex: 1 1 0%;
   min-width: 0;
   padding-right: 5px;
   text-align: right;
@@ -83,7 +83,7 @@
   @extend .rbc-abs-full;
   display: flex;
   flex-direction: row;
-  flex: 1 0 0;
+  flex: 1 0 0%;
   overflow: hidden;
 }
 

--- a/src/sass/time-column.scss
+++ b/src/sass/time-column.scss
@@ -63,7 +63,7 @@
 
   .rbc-event-content {
     width: 100%;
-    flex: 1 1 0;
+    flex: 1 1 0%;
     word-wrap: break-word;
     line-height: 1;
     height: 100%;
@@ -92,7 +92,7 @@
 
   .rbc-time-header-content {
     min-width: auto;
-    flex: 1 0 0;
+    flex: 1 0 0%;
     flex-basis: 0px;
   }
 
@@ -105,10 +105,10 @@
   }
 
   .rbc-header,
-  .rbc-day-bg, {
+  .rbc-day-bg {
     width: 140px;
     // min-width: 0;
-    flex:  1 1 0;
+    flex:  1 1 0px;
     flex-basis: 0 px;
   }
 }
@@ -118,7 +118,7 @@
 }
 
 .rbc-time-slot {
-  flex: 1 0 0;
+  flex: 1 0 0%;
 
   &.rbc-now {
     font-weight: bold;


### PR DESCRIPTION
when flex base does not have a unit % or px it will fails. Before the prefixer add -mx-flex this issue did not occurs. 
might be related to #1142