### PR TITLE
Update time indicator position if max prop changes

### DIFF
--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -63,7 +63,8 @@ class DayColumn extends React.Component {
       }
     } else if (
       this.props.isNow &&
-      !dates.eq(prevProps.min, this.props.min, 'minutes')
+      (!dates.eq(prevProps.min, this.props.min, 'minutes') ||
+        !dates.eq(prevProps.max, this.props.max, 'minutes'))
     ) {
       this.positionTimeIndicator()
     }


### PR DESCRIPTION
The fix in https://github.com/intljusticemission/react-big-calendar/pull/1311 only addressed the case of `min` changing, not the case of `max` changing.

This addresses the same thing as https://github.com/intljusticemission/react-big-calendar/pull/1297 but rebased on top of the changes from #1311

Demonstration: https://codesandbox.io/s/react-big-calendar-bug-5bmvb

@jquense @sonnyp 