### PR TITLE
Fix inaccurate position handling if body is under zoom

### DIFF
--- a/src/Selection.js
+++ b/src/Selection.js
@@ -30,12 +30,14 @@ function getEventCoordinates(e) {
   if (e.touches && e.touches.length) {
     target = e.touches[0]
   }
+  
+  var zoom = parseFloat(window.getComputedStyle(document.body).zoom);
 
   return {
     clientX: target.clientX,
     clientY: target.clientY,
-    pageX: target.pageX,
-    pageY: target.pageY,
+    pageX: target.pageX / zoom,
+    pageY: target.pageY / zoom,
   }
 }
 

--- a/src/Selection.js
+++ b/src/Selection.js
@@ -31,7 +31,7 @@ function getEventCoordinates(e) {
     target = e.touches[0]
   }
   
-  var zoom = parseFloat(window.getComputedStyle(document.body).zoom);
+  var zoom = parseFloat(window.getComputedStyle(document.body).zoom) || 1;
 
   return {
     clientX: target.clientX,

--- a/src/Selection.js
+++ b/src/Selection.js
@@ -31,7 +31,7 @@ function getEventCoordinates(e) {
     target = e.touches[0]
   }
   
-  var zoom = parseFloat(window.getComputedStyle(document.body).zoom) || 1;
+  const zoom = parseFloat(window.getComputedStyle(document.body).zoom) || 1;
 
   return {
     clientX: target.clientX,


### PR DESCRIPTION
relates to https://github.com/intljusticemission/react-big-calendar/issues/785

Currently when calculating pageX and pageY it doesn't consider the body zoom value 

Created a sandbox to demo this issue. The selection position is off in before patch version.

https://codesandbox.io/s/smoosh-star-efem9

