### PR TITLE
Add resourceId to onSelecting callback

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -269,6 +269,7 @@ class Calendar extends React.Component {
      *   slotInfo: {
      *     start: Date,
      *     end: Date,
+     *     resourceId:  (number|string),
      *     slots: Array<Date>,
      *     action: "select" | "click" | "doubleClick",
      *     bounds: ?{ // For "select" action
@@ -317,7 +318,7 @@ class Calendar extends React.Component {
      * Returning `false` from the handler will prevent a selection.
      *
      * ```js
-     * (range: { start: Date, end: Date }) => ?boolean
+     * (range: { start: Date, end: Date, resourceId: (number|string) }) => ?boolean
      * ```
      */
     onSelecting: PropTypes.func,

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -249,7 +249,7 @@ class DayColumn extends React.Component {
         if (
           (dates.eq(current.startDate, start, 'minutes') &&
             dates.eq(current.endDate, end, 'minutes')) ||
-          onSelecting({ start, end }) === false
+          onSelecting({ start, end, resourceId: this.props.resource }) === false
         )
           return
       }


### PR DESCRIPTION
I've added `resourceId` to onSelecting callback since without its impossible to detect which column is selecting when we have resources.