### PR TITLE
fix: remove time indicator when is null

### DIFF
--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -117,12 +117,18 @@ class DayColumn extends React.Component {
     } = this.props
 
     let { slotMetrics } = this
-    let { selecting, top, height, startDate, endDate } = this.state
+    let {
+      selecting,
+      top,
+      height,
+      startDate,
+      endDate,
+      timeIndicatorPosition,
+    } = this.state
 
     let selectDates = { start: startDate, end: endDate }
 
     const { className, style } = dayProp(max)
-
     return (
       <div
         style={style}
@@ -162,10 +168,10 @@ class DayColumn extends React.Component {
             <span>{localizer.format(selectDates, 'selectRangeFormat')}</span>
           </div>
         )}
-        {isNow && (
+        {isNow && timeIndicatorPosition && (
           <div
             className="rbc-current-time-indicator"
-            style={{ top: `${this.state.timeIndicatorPosition}%` }}
+            style={{ top: `${timeIndicatorPosition}%` }}
           />
         )}
       </div>


### PR DESCRIPTION
There are a problem with time `.rbc-current-time-indicator` when timeIndicatorPosition is null and that happens when current hour is bigger or smaller that grid rage.

```js
  positionTimeIndicator() {
    const { min, max, getNow } = this.props
    const current = getNow()

    if (current >= min && current <= max) {
      const { top } = this.slotMetrics.getRange(current, current)
      this.setState({ timeIndicatorPosition: top })
    } else {
      this.clearTimeIndicatorInterval()
    }
  }
```

Then the `.rbc-current-time-indicator` stay on top of daycolumn grid.

> <img src="https://i.ibb.co/vZTzhXg/Screen-Shot-2019-08-20-at-16-25-51.png" />
