### PR TITLE
fix: add new method to get correct time indicator top position | fixes #1396

### DIFF
--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -97,10 +97,7 @@ class DayColumn extends React.Component {
     const current = getNow()
 
     if (current >= min && current <= max) {
-      const top = this.slotMetrics.getCurrentTimeIndicatorRange(
-        current,
-        current
-      )
+      const top = this.slotMetrics.getCurrentTimePosition(current, current)
       this.setState({ timeIndicatorPosition: top })
     } else {
       this.clearTimeIndicatorInterval()

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -97,7 +97,7 @@ class DayColumn extends React.Component {
     const current = getNow()
 
     if (current >= min && current <= max) {
-      const { top } = this.slotMetrics.getCurrentTimeIndicatorRange(
+      const top = this.slotMetrics.getCurrentTimeIndicatorRange(
         current,
         current
       )

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -97,7 +97,10 @@ class DayColumn extends React.Component {
     const current = getNow()
 
     if (current >= min && current <= max) {
-      const { top } = this.slotMetrics.getRange(current, current)
+      const { top } = this.slotMetrics.getCurrentTimeIndicatorRange(
+        current,
+        current
+      )
       this.setState({ timeIndicatorPosition: top })
     } else {
       this.clearTimeIndicatorInterval()

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -97,7 +97,7 @@ class DayColumn extends React.Component {
     const current = getNow()
 
     if (current >= min && current <= max) {
-      const top = this.slotMetrics.getCurrentTimePosition(current, current)
+      const top = this.slotMetrics.getCurrentTimePosition(current)
       this.setState({ timeIndicatorPosition: top })
     } else {
       this.clearTimeIndicatorInterval()

--- a/src/utils/TimeSlots.js
+++ b/src/utils/TimeSlots.js
@@ -150,17 +150,9 @@ export function getSlotMetrics({ min: start, max: end, step, timeslots }) {
       if (!ignoreMax) rangeEnd = dates.min(end, dates.max(start, rangeEnd))
 
       const rangeStartMin = positionFromDate(rangeStart)
-      const rangeEndMin = positionFromDate(rangeEnd)
       const top = (rangeStartMin / (step * numSlots)) * 100
 
-      return {
-        top,
-        height: (rangeEndMin / (step * numSlots)) * 100 - top,
-        start: positionFromDate(rangeStart),
-        startDate: rangeStart,
-        end: positionFromDate(rangeEnd),
-        endDate: rangeEnd,
-      }
+      return top
     },
   }
 }

--- a/src/utils/TimeSlots.js
+++ b/src/utils/TimeSlots.js
@@ -145,7 +145,7 @@ export function getSlotMetrics({ min: start, max: end, step, timeslots }) {
       }
     },
 
-    getCurrentTimeIndicatorRange(rangeStart, rangeEnd, ignoreMin, ignoreMax) {
+    getCurrentTimePosition(rangeStart, rangeEnd, ignoreMin, ignoreMax) {
       if (!ignoreMin) rangeStart = dates.min(end, dates.max(start, rangeStart))
       if (!ignoreMax) rangeEnd = dates.min(end, dates.max(start, rangeEnd))
 

--- a/src/utils/TimeSlots.js
+++ b/src/utils/TimeSlots.js
@@ -145,10 +145,7 @@ export function getSlotMetrics({ min: start, max: end, step, timeslots }) {
       }
     },
 
-    getCurrentTimePosition(rangeStart, rangeEnd, ignoreMin, ignoreMax) {
-      if (!ignoreMin) rangeStart = dates.min(end, dates.max(start, rangeStart))
-      if (!ignoreMax) rangeEnd = dates.min(end, dates.max(start, rangeEnd))
-
+    getCurrentTimePosition(rangeStart) {
       const rangeStartMin = positionFromDate(rangeStart)
       const top = (rangeStartMin / (step * numSlots)) * 100
 

--- a/src/utils/TimeSlots.js
+++ b/src/utils/TimeSlots.js
@@ -125,10 +125,8 @@ export function getSlotMetrics({ min: start, max: end, step, timeslots }) {
     },
 
     getRange(rangeStart, rangeEnd, ignoreMin, ignoreMax) {
-      if (!ignoreMin)
-        rangeStart = dates.min(end, dates.max(start, rangeStart))
-      if (!ignoreMax)
-        rangeEnd = dates.min(end, dates.max(start, rangeEnd))
+      if (!ignoreMin) rangeStart = dates.min(end, dates.max(start, rangeStart))
+      if (!ignoreMax) rangeEnd = dates.min(end, dates.max(start, rangeEnd))
 
       const rangeStartMin = positionFromDate(rangeStart)
       const rangeEndMin = positionFromDate(rangeEnd)
@@ -136,6 +134,24 @@ export function getSlotMetrics({ min: start, max: end, step, timeslots }) {
         rangeEndMin - rangeStartMin < step
           ? ((rangeStartMin - step) / (step * numSlots)) * 100
           : (rangeStartMin / (step * numSlots)) * 100
+
+      return {
+        top,
+        height: (rangeEndMin / (step * numSlots)) * 100 - top,
+        start: positionFromDate(rangeStart),
+        startDate: rangeStart,
+        end: positionFromDate(rangeEnd),
+        endDate: rangeEnd,
+      }
+    },
+
+    getCurrentTimeIndicatorRange(rangeStart, rangeEnd, ignoreMin, ignoreMax) {
+      if (!ignoreMin) rangeStart = dates.min(end, dates.max(start, rangeStart))
+      if (!ignoreMax) rangeEnd = dates.min(end, dates.max(start, rangeEnd))
+
+      const rangeStartMin = positionFromDate(rangeStart)
+      const rangeEndMin = positionFromDate(rangeEnd)
+      const top = (rangeStartMin / (step * numSlots)) * 100
 
       return {
         top,


### PR DESCRIPTION
The function used to set the current time indicator (getRange) was changed in #1204 to fix #1203 but it broke the top position of the current time indicator as in #1396 
I have made a new function (getCurrentTimeIndicatorRange) that does almost the same as (getRange) but it is specific to current time indicator so there will be no conflict between how events are displayed and how time indicator is displayed.