### PR TITLE
Fix end slot selection

### DIFF
--- a/src/utils/TimeSlots.js
+++ b/src/utils/TimeSlots.js
@@ -130,7 +130,10 @@ export function getSlotMetrics({ min: start, max: end, step, timeslots }) {
 
       const rangeStartMin = positionFromDate(rangeStart)
       const rangeEndMin = positionFromDate(rangeEnd)
-      const top = (rangeStartMin / (step * numSlots)) * 100
+      const top =
+        rangeEndMin - rangeStartMin < step && !dates.eq(end, rangeEnd)
+          ? ((rangeStartMin - step) / (step * numSlots)) * 100
+          : (rangeStartMin / (step * numSlots)) * 100
 
       return {
         top,

--- a/src/utils/TimeSlots.js
+++ b/src/utils/TimeSlots.js
@@ -130,10 +130,7 @@ export function getSlotMetrics({ min: start, max: end, step, timeslots }) {
 
       const rangeStartMin = positionFromDate(rangeStart)
       const rangeEndMin = positionFromDate(rangeEnd)
-      const top =
-        rangeEndMin - rangeStartMin < step
-          ? ((rangeStartMin - step) / (step * numSlots)) * 100
-          : (rangeStartMin / (step * numSlots)) * 100
+      const top = (rangeStartMin / (step * numSlots)) * 100
 
       return {
         top,


### PR DESCRIPTION
Selection works correctly though visually there were two slots selected. I'm not sure what this logic was resposible for but it affected only end slot because of smaller range (30-59min) instead of 30-00.

![Kapture 2019-09-12 at 18 33 37](https://user-images.githubusercontent.com/5635476/64798554-df989500-d58b-11e9-8246-86b50ea67db5.gif)

![Kapture 2019-09-12 at 18 32 55](https://user-images.githubusercontent.com/5635476/64798559-e2938580-d58b-11e9-9979-9203dae13853.gif)
