### PR TITLE
prevent showing timeIndicator when indicator is outside of Calendar's min/max range

### DIFF
--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -162,7 +162,7 @@ class DayColumn extends React.Component {
             <span>{localizer.format(selectDates, 'selectRangeFormat')}</span>
           </div>
         )}
-        {isNow && (
+        {isNow && this.state.timeIndicatorPosition && (
           <div
             className="rbc-current-time-indicator"
             style={{ top: `${this.state.timeIndicatorPosition}%` }}


### PR DESCRIPTION
I haven't tested other views yet but the timeline indicator is visible for the Day view when the time indicator is outside of the Calendar's set min/max values.

`this.state.timelineIndicatorPosition` will be `null` when min/max is set and the time indicator is before/after those values which causes the indicator to display at the top of the calendar.