### PR TITLE
needLimitMeasure must always true. to make 'x_more' works

### DIFF
--- a/src/Month.js
+++ b/src/Month.js
@@ -35,7 +35,7 @@ class MonthView extends React.Component {
     }
   }
 
-  componentWillReceiveProps({ date }) {
+  componentWillReceiveProps() {
     this.setState({
       needLimitMeasure: true,
     })

--- a/src/Month.js
+++ b/src/Month.js
@@ -37,7 +37,7 @@ class MonthView extends React.Component {
 
   componentWillReceiveProps({ date }) {
     this.setState({
-      needLimitMeasure: !dates.eq(date, this.props.date, 'month'),
+      needLimitMeasure: true,
     })
   }
 


### PR DESCRIPTION
**AS-IS**: 
First time events loaded, month is same as default. So 'x_more' will not show. Until I try to resize window it come.
