### PR TITLE
Fix React 16.9 warnings

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "./dist/react-big-calendar.js": {
-    "bundled": 501317,
-    "minified": 146786,
-    "gzipped": 44762
+    "bundled": 501555,
+    "minified": 146873,
+    "gzipped": 44787
   },
   "./dist/react-big-calendar.min.js": {
-    "bundled": 439004,
-    "minified": 127972,
-    "gzipped": 40409
+    "bundled": 439172,
+    "minified": 128058,
+    "gzipped": 40429
   },
   "dist/react-big-calendar.esm.js": {
-    "bundled": 168678,
-    "minified": 80552,
-    "gzipped": 19913,
+    "bundled": 168912,
+    "minified": 80639,
+    "gzipped": 19930,
     "treeshaked": {
       "rollup": {
-        "code": 58283,
+        "code": 58369,
         "import_statements": 1578
       },
       "webpack": {
-        "code": 62787
+        "code": 62884
       }
     }
   }

--- a/src/BackgroundCells.js
+++ b/src/BackgroundCells.js
@@ -25,7 +25,7 @@ class BackgroundCells extends React.Component {
     this._teardownSelectable()
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.selectable && !this.props.selectable) this._selectable()
 
     if (!nextProps.selectable && this.props.selectable)

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -752,7 +752,7 @@ class Calendar extends React.Component {
       context: this.getContext(this.props),
     }
   }
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState({ context: this.getContext(nextProps) })
   }
 

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -35,7 +35,7 @@ class DayColumn extends React.Component {
     this.clearTimeIndicatorInterval()
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.selectable && !this.props.selectable) this._selectable()
     if (!nextProps.selectable && this.props.selectable)
       this._teardownSelectable()

--- a/src/Month.js
+++ b/src/Month.js
@@ -35,7 +35,7 @@ class MonthView extends React.Component {
     }
   }
 
-  componentWillReceiveProps({ date }) {
+  UNSAFE_componentWillReceiveProps({ date }) {
     this.setState({
       needLimitMeasure: !dates.eq(date, this.props.date, 'month'),
     })

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -25,7 +25,7 @@ export default class TimeGrid extends Component {
     this.contentRef = React.createRef()
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.calculateScroll()
   }
 
@@ -71,7 +71,7 @@ export default class TimeGrid extends Component {
     //this.checkOverflow()
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { range, scrollToTime } = this.props
     // When paginating, reset scroll
     if (

--- a/src/TimeGutter.js
+++ b/src/TimeGutter.js
@@ -18,7 +18,7 @@ export default class TimeGutter extends Component {
     })
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { min, max, timeslots, step } = nextProps
     this.slotMetrics = this.slotMetrics.update({ min, max, timeslots, step })
   }


### PR DESCRIPTION
This PR fixes warning from React 16.9+ and stops the lib from breaking in the upcoming React 17 version.

Fixes https://github.com/intljusticemission/react-big-calendar/issues/1481