### PR TITLE
Add height style to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ const MyCalendar = props => (
       events={myEventsList}
       startAccessor="start"
       endAccessor="end"
+      style={{height: 500}}
     />
   </div>
 )
@@ -71,6 +72,7 @@ const MyCalendar = props => (
       events={myEventsList}
       startAccessor="start"
       endAccessor="end"
+      style={{height: 500}}
     />
   </div>
 )


### PR DESCRIPTION
Make the examples more clear in the readme file that the height is required in order for things to render correctly.