### PR TITLE
add custom prop validation for min and max

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -25,6 +25,7 @@ import defaults from 'lodash/defaults'
 import transform from 'lodash/transform'
 import mapValues from 'lodash/mapValues'
 import { wrapAccessor } from './utils/accessors'
+import { isValidDateObject } from './utils/dates';
 
 function viewNames(_views) {
   return !Array.isArray(_views) ? Object.keys(_views) : _views
@@ -519,12 +520,22 @@ class Calendar extends React.Component {
     /**
      * Constrains the minimum _time_ of the Day and Week views.
      */
-    min: PropTypes.instanceOf(Date),
+    min: (props, propName, componentName) => {
+      const minValue = props[propName];
+      if (!isValidDateObject(minValue)) {
+        return new Error(`Invalid prop ${propName} supplied to ${componentName}. Must be a valid instance of Date.`)
+      }
+    },
 
     /**
      * Constrains the maximum _time_ of the Day and Week views.
      */
-    max: PropTypes.instanceOf(Date),
+    max: (props, propName, componentName) => {
+      const maxValue = props[propName];
+      if (!isValidDateObject(maxValue)) {
+        return new Error(`Invalid prop ${propName} supplied to ${componentName}. Must be a valid instance of Date.`)
+      }
+    },
 
     /**
      * Determines how far down the scroll pane is initially scrolled down.

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -168,3 +168,7 @@ export function yesterday() {
 export function tomorrow() {
   return dates.add(dates.startOf(new Date(), 'day'), 1, 'day')
 }
+
+export function isValidDateObject(date) {
+  return date instanceof Date && !isNaN(date);
+}


### PR DESCRIPTION
I ran into an issue that I had to spend some time tracking down last night (#1502), and it turns out that Safari and Chrome were parsing a Date object differently, and it was invalid according to Safari, though still an instance of Date. So, to prevent this from causing confusion down the road, I updated the prop-type validation for the `min` and `max` props to _also_ check to make sure that the values passed in are _valid_ Date objects, via `isNaN`.