### PR TITLE
chore(github-actions): add semantic release and test workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,10 @@ jobs:
         with:
           node-version: '12.x'
 
-      - name: Install yarn
-        run: sudo apt update && sudo apt install yarn
-
       - name: Install Dependencies
         run: yarn install
 
-      - name: Jest Unit Test & Linting
+      - name: Unit Test & Linting
         run: yarn test
 
       - name: Build
@@ -40,5 +37,5 @@ jobs:
             @semantic-release/changelog
 
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN_KEY }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+
+      - name: Install yarn
+        run: sudo apt update && sudo apt install yarn
+
+      - name: Install Dependencies
+        run: yarn install
+
+      - name: Jest Unit Test & Linting
+        run: yarn test
+
+      - name: Build
+        run: yarn build
+
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@master
+        id: semantic
+        with:
+          branch: master
+          extra_plugins: |
+            @semantic-release/git
+            @semantic-release/changelog
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN_KEY }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Test
 
-on: [push, pull_request]
+on: [pull_request]
+
 
 jobs:
   test:
@@ -15,13 +16,10 @@ jobs:
         with:
           node-version: '12.x'
 
-      - name: Install yarn
-        run: sudo apt update && sudo apt install yarn
-
       - name: Install Dependencies
         run: yarn install
 
-      - name: Jest Unit Test & Linting
+      - name: Unit Test & Linting
         run: yarn test
 
       - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+
+      - name: Install yarn
+        run: sudo apt update && sudo apt install yarn
+
+      - name: Install Dependencies
+        run: yarn install
+
+      - name: Jest Unit Test & Linting
+        run: yarn test
+
+      - name: Build
+        run: yarn build


### PR DESCRIPTION
Improve the releasing setup 
---

Addresses issue #1519

Tools used: [Github Actions](https://help.github.com/en/github/automating-your-workflow-with-github-actions/about-github-actions) |  [Semantic Release](https://github.com/semantic-release/semantic-release)

This PR introduces 2 workflows
1. Tests Workflow: Runs in every PR and ensures that tests & linting are passing 
    - This flow is been tested here ✅[more details](https://github.com/KhaledMohamedP/react-big-calendar/commit/60b9478d75bf84e599bb44833ee8d0953a1741c8/checks?check_suite_id=293604078)
2. Release Workflow: Runs when anything gets pushed to master
    - Releasing involve pushing to npm registry and adding a release tag
    - This flow has not been fully tested, due to missing npm/github tokens ❌[more details](https://github.com/KhaledMohamedP/react-big-calendar/commit/a5790e34271d10e301abcbefc7e14d5176c4baab/checks?check_suite_id=293614141) 

Add Secrets
--- 
This action is required before merging:

Please add the following secrets needed for semantic release to enable publishing and git tags. 
1. `GITHUB_TOKEN` 
2. `NPM_TOKEN`

From the repo settings, navigate to `repo -> settings -> secrets` [more info here](https://help.github.com/en/github/automating-your-workflow-with-github-actions/virtual-environments-for-github-actions#creating-and-using-secrets-encrypted-variables)

