### PR TITLE
Prefix all deprecated React lifecycle methods with UNSAFE

### DIFF
--- a/src/BackgroundCells.js
+++ b/src/BackgroundCells.js
@@ -25,7 +25,7 @@ class BackgroundCells extends React.Component {
     this._teardownSelectable()
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.selectable && !this.props.selectable) this._selectable()
 
     if (!nextProps.selectable && this.props.selectable)

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -761,7 +761,7 @@ class Calendar extends React.Component {
       context: this.getContext(this.props),
     }
   }
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState({ context: this.getContext(nextProps) })
   }
 

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -37,7 +37,7 @@ class DayColumn extends React.Component {
     this.clearTimeIndicatorInterval()
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.selectable && !this.props.selectable) this._selectable()
     if (!nextProps.selectable && this.props.selectable)
       this._teardownSelectable()

--- a/src/Month.js
+++ b/src/Month.js
@@ -35,7 +35,7 @@ class MonthView extends React.Component {
     }
   }
 
-  componentWillReceiveProps({ date }) {
+  UNSAFE_componentWillReceiveProps({ date }) {
     this.setState({
       needLimitMeasure: !dates.eq(date, this.props.date, 'month'),
     })

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -27,7 +27,7 @@ export default class TimeGrid extends Component {
     this._scrollRatio = null
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.calculateScroll()
   }
 
@@ -73,7 +73,7 @@ export default class TimeGrid extends Component {
     //this.checkOverflow()
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { range, scrollToTime } = this.props
     // When paginating, reset scroll
     if (

--- a/src/TimeGutter.js
+++ b/src/TimeGutter.js
@@ -18,7 +18,7 @@ export default class TimeGutter extends Component {
     })
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { min, max, timeslots, step } = nextProps
     this.slotMetrics = this.slotMetrics.update({ min, max, timeslots, step })
   }


### PR DESCRIPTION
There hasn't been any movement on #1515 or #1560 lately, so I thought I'd open this simple fix.

This PR prefixes all deprecated React lifecycle methods with the `UNSAFE_` keyword. In the long term these lifecycle methods should be refactored out, but in the interim there is no reason we need to continue to see the console full of warnings. 

For more context:
https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html